### PR TITLE
[IDX-3749] - Add cache replacement prerequisites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(cachemere
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/presets.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/detail/traits.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_lru.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_lru.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_gdsf.h>

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -67,6 +67,19 @@ public:
     /// @return Whether the item was inserted in cache.
     bool insert(const Key& key, const Value& value);
 
+    /// @brief Remove a key and its value from the cache.
+    /// @details If the key is not present in cache, no operation is taken.
+    /// @param key The key to remove from the cache.
+    /// @return Whether the key was present in cache.
+    bool remove(const Key& key);
+
+    /// @brief Retain all objects matching a predicate.
+    /// @details Removes all items for which `predicate_fn` returns false.
+    /// @param predicate_fn The predicate function.
+    /// @tparam P The type of the predicate function.
+    ///           The predicate should have the signature `bool fn(const Key& key, const Value& value)`.
+    template<typename P> void retain(P predicate_fn);
+
     /// @brief Get the number of items currently stored in the cache.
     /// @warning This method acquires a mutual exclusion lock to secure the item count.
     ///          Calling this excessively while the cache is under contention will be detrimental to performance.
@@ -114,6 +127,7 @@ public:
 private:
     using CacheItem = Item<Key, Value>;
     using DataMap   = std::map<Key, CacheItem>;
+    using DataMapIt = typename DataMap::iterator;
 
     using MyInsertionPolicySP = std::unique_ptr<MyInsertionPolicy>;
     using MyEvictionPolicySP  = std::unique_ptr<MyEvictionPolicy>;
@@ -139,6 +153,7 @@ private:
 
     bool   compare_evict(const Key& candidate_key, size_t candidate_size);
     size_t free_amount(size_t amount_to_free);
+    void   remove(DataMapIt it);
 
     void on_insert(const CacheItem& item) const;
     void on_update(const CacheItem& item) const;

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -1,0 +1,51 @@
+#ifndef CACHEMERE_TRAITS_H
+#define CACHEMERE_TRAITS_H
+
+#include "cachemere/item.h"
+
+namespace cachemere::detail::traits {
+
+// Traits for STL types.
+namespace stl {
+
+template<typename T>
+constexpr auto has_reserve = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).reserve(std::declval<size_t>())) {
+})(boost::hana::type_c<T>);
+
+template<typename T>
+constexpr auto has_size = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).size()) {})(boost::hana::type_c<T>);
+
+template<typename T, typename... Args>
+constexpr auto has_emplace_back = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).emplace_back(std::declval<Args>()...)) {
+})(boost::hana::type_c<T>);
+
+}  // namespace stl
+
+// Traits for cache event handlers.
+namespace event {
+
+template<typename K, typename V, template<class, class> typename P>
+constexpr auto has_on_insert = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).on_insert(std::declval<Item<K, V>>())) {
+})(boost::hana::type_c<P<K, V>>);
+
+template<typename K, typename V, template<class, class> typename P>
+constexpr auto has_on_update = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).on_update(std::declval<Item<K, V>>())) {
+})(boost::hana::type_c<P<K, V>>);
+
+template<typename K, typename V, template<class, class> typename P>
+constexpr auto has_on_cachehit = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).on_cache_hit(std::declval<Item<K, V>>())) {
+})(boost::hana::type_c<P<K, V>>);
+
+template<typename K, typename V, template<class, class> typename P>
+constexpr auto has_on_cachemiss = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).on_cache_miss(std::declval<K>())) {
+})(boost::hana::type_c<P<K, V>>);
+
+template<typename K, typename V, template<class, class> typename P>
+constexpr auto has_on_evict = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).on_evict(std::declval<K>())) {
+})(boost::hana::type_c<P<K, V>>);
+
+}  // namespace event
+
+}  // namespace cachemere::detail::traits
+
+#endif

--- a/include/cachemere/policy/eviction_lru.hpp
+++ b/include/cachemere/policy/eviction_lru.hpp
@@ -61,10 +61,15 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_evict(const Ke
 {
     assert(!m_nodes.empty());
     assert(!m_keys.empty());
-    assert(m_keys.back().get() == key);
 
-    m_nodes.erase(key);
-    m_keys.pop_back();
+    if (m_keys.back().get() == key) {
+        m_nodes.erase(key);
+        m_keys.pop_back();
+    } else {
+        auto it = m_nodes.find(key);
+        assert(it != m_nodes.end());
+        m_nodes.erase(it);
+    }
 }
 
 template<class Key, class Value> auto EvictionLRU<Key, Value>::victim_begin() const -> VictimIterator

--- a/include/cachemere/presets.h
+++ b/include/cachemere/presets.h
@@ -19,8 +19,8 @@ namespace cachemere::presets {
 /// @tparam Value The type of the items stored in the cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
-template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>>
-using LRUCache = Cache<Key, Value, policy::InsertionAlways, policy::EvictionLRU, MeasureValue, MeasureKey>;
+template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
+using LRUCache = Cache<Key, Value, policy::InsertionAlways, policy::EvictionLRU, MeasureValue, MeasureKey, ThreadSafe>;
 
 /// @brief TinyLFU Cache.
 /// @details Uses a combination of frequency sketches to gather a decent estimate of the access frequency of most keys.
@@ -29,20 +29,20 @@ using LRUCache = Cache<Key, Value, policy::InsertionAlways, policy::EvictionLRU,
 /// @tparam Value The type of the items stored in the cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
-template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>>
-using TinyLFUCache = Cache<Key, Value, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU, MeasureValue, MeasureKey>;
+template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
+using TinyLFUCache = Cache<Key, Value, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU, MeasureValue, MeasureKey, ThreadSafe>;
 
 namespace detail {
 
 // Template helper to allow partial specialization of Cost.
-template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>>
+template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
 class SpecializedGDSFCache
 {
 private:
     template<typename K, typename V> using MyGDSF = policy::EvictionGDSF<K, V, Cost>;
 
 public:
-    using type = Cache<Key, Value, policy::InsertionAlways, MyGDSF, MeasureValue, MeasureKey>;
+    using type = Cache<Key, Value, policy::InsertionAlways, MyGDSF, MeasureValue, MeasureKey, ThreadSafe>;
 };
 
 }  // namespace detail
@@ -54,8 +54,8 @@ public:
 /// @tparam Cost A functor taking a `const Item<Key, Value>&` returning the cost to load this item in cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
-template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>>
-using CustomCostCache = typename detail::SpecializedGDSFCache<Key, Value, Cost, MeasureValue, MeasureKey>::type;
+template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
+using CustomCostCache = typename detail::SpecializedGDSFCache<Key, Value, Cost, MeasureValue, MeasureKey, ThreadSafe>::type;
 
 }  // namespace cachemere::presets
 

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
 
+#include <list>
+#include <map>
 #include <random>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 #include "cachemere/cache.h"
 #include "cachemere/measurement.h"
@@ -181,4 +184,69 @@ TYPED_TEST(CacheTest, Retain)
             EXPECT_FALSE(cache->contains(point_id));
         }
     }
+}
+
+TYPED_TEST(CacheTest, Collect)
+{
+    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
+
+    const uint32_t number_of_items = 5;
+
+    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
+        cache->find(point_id);
+        cache->insert(point_id, Point3D{point_id, point_id, point_id});
+    }
+
+    // Test with various STL collection types.
+    std::vector<std::pair<uint32_t, Point3D>> item_vec;
+    cache->collect_into(item_vec);
+    EXPECT_EQ(item_vec.size(), number_of_items);
+
+    std::map<uint32_t, Point3D> item_map;
+    cache->collect_into(item_map);
+    EXPECT_EQ(item_map.size(), number_of_items);
+
+    std::list<std::pair<uint32_t, Point3D>> item_list;
+    cache->collect_into(item_list);
+    EXPECT_EQ(item_list.size(), number_of_items);
+
+    std::unordered_map<uint32_t, Point3D> item_unordered_map;
+    cache->collect_into(item_unordered_map);
+    EXPECT_EQ(item_unordered_map.size(), number_of_items);
+
+    // Test with a custom collection that doesn't support size or reserve.
+    struct CustomCollection {
+        void emplace(const uint32_t& key, const Point3D& value)
+        {
+            m_data.emplace(key, value);
+        }
+
+        std::map<uint32_t, Point3D> m_data;
+    };
+
+    CustomCollection items_custom;
+    cache->collect_into(items_custom);
+    EXPECT_EQ(items_custom.m_data.size(), number_of_items);
+}
+
+TYPED_TEST(CacheTest, Swap)
+{
+    auto cache_even = TestFixture::new_cache(10 * sizeof(Point3D));
+    auto cache_odd  = TestFixture::new_cache(10 * sizeof(Point3D));
+
+    const uint32_t number_of_items = 10;
+
+    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
+        auto& target_cache = point_id % 2 == 0 ? cache_even : cache_odd;
+
+        target_cache->find(point_id);
+        target_cache->insert(point_id, Point3D{point_id, point_id, point_id});
+    }
+
+    using std::swap;
+    swap(*cache_even, *cache_odd);
+
+    EXPECT_TRUE(cache_even->contains(7));
+    EXPECT_TRUE(cache_odd->contains(4));
+    EXPECT_FALSE(cache_even->contains(2));
 }

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -143,3 +143,42 @@ TYPED_TEST(CacheTest, Resize)
     EXPECT_LE(cache->size(), 4 * sizeof(Point3D));
     EXPECT_EQ(cache->number_of_items(), 2);  // Only two items fit because of the cache overhead.
 }
+
+TYPED_TEST(CacheTest, RemoveWhenKeyPresent)
+{
+    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
+
+    cache->find(0);
+    cache->insert(0, Point3D{0, 0, 0});
+
+    EXPECT_TRUE(cache->contains(0));
+    EXPECT_TRUE(cache->remove(0));
+    EXPECT_FALSE(cache->contains(0));
+}
+
+TYPED_TEST(CacheTest, RemoveWhenKeyAbsent)
+{
+    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
+    EXPECT_FALSE(cache->remove(0));
+}
+
+TYPED_TEST(CacheTest, Retain)
+{
+    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
+
+    const uint32_t number_of_items = 5;
+    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
+        cache->find(point_id);
+        cache->insert(point_id, Point3D{point_id, point_id, point_id});
+    }
+
+    cache->retain([](const uint32_t& key, const Point3D& value) { return key % 2 == 0; });
+
+    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
+        if (point_id % 2 == 0) {
+            EXPECT_TRUE(cache->contains(point_id));
+        } else {
+            EXPECT_FALSE(cache->contains(point_id));
+        }
+    }
+}

--- a/tests/src/policy/eviction_gdsf_tests.cpp
+++ b/tests/src/policy/eviction_gdsf_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <set>
 #include <string>
 
 #include "cachemere/policy/eviction_gdsf.h"
@@ -98,4 +99,24 @@ TEST(EvictionGDSF, MaximizeCostPerByteWithQuadraticCost)
         policy.on_update(key_and_item->second);
     }
     EXPECT_EQ(*policy.victim_begin(), short_key);
+}
+
+TEST(EvictionGDSF, VictimIteration)
+{
+    QuadraticCostGDSF policy;
+
+    ItemMap item_store;
+
+    const std::vector<std::string> keys{"a", "b", "c", "d", "e"};
+    for (size_t i = 0; i < keys.size(); ++i) {
+        insert_item(keys[i], static_cast<int32_t>(i), policy, item_store);
+    }
+
+    const std::set<std::string> expected_key_set{keys.begin(), keys.end()};
+    std::set<std::string>       key_set;
+    for (auto it = policy.victim_begin(); it != policy.victim_end(); ++it) {
+        key_set.insert(*it);
+    }
+
+    EXPECT_EQ(key_set, expected_key_set);
 }


### PR DESCRIPTION
This adds some prerequisite features for our use cases. With this we should have everything we need in cachemere to start integrating the cache in the index.

Namely:
-  `Cache::remove(const K& key)`
-  `Cache::retain(P predicate_fn)` (to remove multiple keys under a single lock)
-  `Cache::collect_into(C& collection)`
-  `swap(Cache& lhs, Cache& rhs)`
-  Parameter to disable locking at compile-time

Also, since `collect_into` required some new uses of `boost::hana` , I refactored the existing usages of hana (for detecting event handler presence on policies) into a single header ( `traits.h` )