### PR TITLE
[IDX-3750] - Add clear method and fix swap-related things

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -1,7 +1,6 @@
 #ifndef CACHEMERE_CACHE_H
 #define CACHEMERE_CACHE_H
 
-#include <atomic>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -157,9 +156,9 @@ private:
     using RollingMeanStatistics = boost::accumulators::stats<RollingMeanTag>;
     using MeanAccumulator       = boost::accumulators::accumulator_set<uint32_t, RollingMeanStatistics>;
 
-    std::atomic<size_t> m_current_size;
-    std::atomic<size_t> m_maximum_size;
-    uint32_t            m_statistics_window_size;
+    size_t   m_current_size;
+    size_t   m_maximum_size;
+    uint32_t m_statistics_window_size;
 
     MyInsertionPolicySP m_insertion_policy;
     MyEvictionPolicySP  m_eviction_policy;

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -84,6 +84,9 @@ public:
     /// @return Whether the key was present in cache.
     bool remove(const Key& key);
 
+    /// @brief Clears the cache contents.
+    void clear();
+
     /// @brief Retain all objects matching a predicate.
     /// @details Removes all items for which `predicate_fn` returns false.
     /// @param predicate_fn The predicate function.
@@ -156,6 +159,7 @@ private:
 
     std::atomic<size_t> m_current_size;
     std::atomic<size_t> m_maximum_size;
+    uint32_t            m_statistics_window_size;
 
     MyInsertionPolicySP m_insertion_policy;
     MyEvictionPolicySP  m_eviction_policy;

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -44,7 +44,7 @@ class Cache
 public:
     using MyInsertionPolicy = InsertionPolicy<Key, Value>;
     using MyEvictionPolicy  = EvictionPolicy<Key, Value>;
-    using CacheType         = Cache<Key, Value, InsertionPolicy, EvictionPolicy, MeasureValue, MeasureKey>;
+    using CacheType         = Cache<Key, Value, InsertionPolicy, EvictionPolicy, MeasureValue, MeasureKey, ThreadSafe>;
 
     /// @brief Simple constructor.
     /// @param maximum_size The maximum amount memory to be used by the cache (in bytes).

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -196,14 +196,14 @@ inline size_t Cache<K, V, I, E, SV, SK, TS>::number_of_items() const
 template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
 inline size_t Cache<K, V, I, E, SV, SK, TS>::size() const
 {
-    std::unique_lock<std::mutex> me_guard(lock());
+    std::unique_lock<std::mutex> guard(lock());
     return m_current_size;
 }
 
 template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
 inline size_t Cache<K, V, I, E, SV, SK, TS>::maximum_size() const
 {
-    std::unique_lock<std::mutex> me_guard(lock());
+    std::unique_lock<std::mutex> guard(lock());
     return m_maximum_size;
 }
 

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -178,15 +178,8 @@ void Cache<K, V, I, E, SV, SK, TS>::swap(CacheType& other)
 
     using std::swap;
 
-    // Atomics don't implement swap, we can do it manually because we currently hold the lock.
-    size_t value         = m_current_size;
-    m_current_size       = other.m_current_size.load();
-    other.m_current_size = value;
-    value                = m_maximum_size;
-    m_maximum_size       = other.m_maximum_size.load();
-    other.m_maximum_size = value;
-
-    // Swap the rest of the members.
+    swap(m_current_size, other.m_current_size);
+    swap(m_maximum_size, other.m_maximum_size);
     swap(m_measure_key, other.m_measure_key);
     swap(m_measure_value, other.m_measure_value);
     swap(m_data, other.m_data);
@@ -203,12 +196,14 @@ inline size_t Cache<K, V, I, E, SV, SK, TS>::number_of_items() const
 template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
 inline size_t Cache<K, V, I, E, SV, SK, TS>::size() const
 {
+    std::unique_lock<std::mutex> me_guard(lock());
     return m_current_size;
 }
 
 template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
 inline size_t Cache<K, V, I, E, SV, SK, TS>::maximum_size() const
 {
+    std::unique_lock<std::mutex> me_guard(lock());
     return m_maximum_size;
 }
 

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -55,6 +55,9 @@ public:
         PrioritySetIt m_iterator;
     };
 
+    /// @brief Clears the policy.
+    void clear();
+
     /// @brief Set the cardinality of the policy.
     /// @details The set cardinality should be a decent approximation of the cardinality
     ///          of the set of keys that _might_ be inserted in the cache. Getting an

--- a/include/cachemere/policy/eviction_gdsf.hpp
+++ b/include/cachemere/policy/eviction_gdsf.hpp
@@ -42,6 +42,13 @@ template<class Key, class Value, class Cost> bool EvictionGDSF<Key, Value, Cost>
     return m_iterator != other.m_iterator;
 }
 
+template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::clear()
+{
+    m_priority_set.clear();
+    m_iterator_map.clear();
+    m_frequency_sketch.clear();
+}
+
 template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::set_cardinality(uint32_t cardinality)
 {
     m_frequency_sketch = detail::CountingBloomFilter<Key>{cardinality};

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -45,6 +45,9 @@ public:
         KeyRefReverseIt m_iterator;
     };
 
+    /// @brief Clears the policy.
+    void clear();
+
     /// @brief Insertion event handler.
     /// @details Inserts the provided item at the front of the list.
     /// @param item The item that has been inserted in cache.

--- a/include/cachemere/policy/eviction_lru.hpp
+++ b/include/cachemere/policy/eviction_lru.hpp
@@ -30,6 +30,12 @@ template<class Key, class Value> bool EvictionLRU<Key, Value>::VictimIterator::o
     return m_iterator != other.m_iterator;
 }
 
+template<class Key, class Value> void EvictionLRU<Key, Value>::clear()
+{
+    m_keys.clear();
+    m_nodes.clear();
+}
+
 template<class Key, class Value> void EvictionLRU<Key, Value>::on_insert(const CacheItem& item)
 {
     assert(m_nodes.find(std::ref(item.m_key)) == m_nodes.end());  // Validate the item is not already in policy.

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -46,6 +46,9 @@ public:
         bool            m_done_with_probation;
     };
 
+    /// @brief Clears the policy.
+    void clear();
+
     /// @brief Set the maximum number of items in the protected LRU segment.
     /// @param size The maximum number of items in the protected segment.
     void set_protected_segment_size(size_t size);

--- a/include/cachemere/policy/eviction_segmented_lru.hpp
+++ b/include/cachemere/policy/eviction_segmented_lru.hpp
@@ -46,6 +46,15 @@ template<class Key, class Value> bool EvictionSegmentedLRU<Key, Value>::VictimIt
     return !(*this == other);
 }
 
+template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::clear()
+{
+    m_probation_list.clear();
+    m_probation_nodes.clear();
+
+    m_protected_list.clear();
+    m_protected_nodes.clear();
+}
+
 template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::set_protected_segment_size(size_t size)
 {
     m_protected_segment_size = size;

--- a/include/cachemere/policy/insertion_always.h
+++ b/include/cachemere/policy/insertion_always.h
@@ -9,6 +9,9 @@ namespace cachemere::policy {
 template<typename Key, typename Value> class InsertionAlways
 {
 public:
+    /// @brief Clears the policy.
+    void clear();
+
     /// @brief Determines whether a given key should be inserted into the cache.
     /// @details For this policy, `should_add` always returns true.
     /// @param key The key of the insertion candidate.

--- a/include/cachemere/policy/insertion_always.hpp
+++ b/include/cachemere/policy/insertion_always.hpp
@@ -1,5 +1,9 @@
 namespace cachemere::policy {
 
+template<typename Key, typename Value> void InsertionAlways<Key, Value>::clear()
+{
+}
+
 template<typename Key, typename Value> bool InsertionAlways<Key, Value>::should_add(const Key& /* key */)
 {
     return true;

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -20,6 +20,9 @@ template<typename Key, typename Value> class InsertionTinyLFU
 public:
     using CacheItem = cachemere::Item<Key, Value>;
 
+    /// @brief Clears the policy.
+    void clear();
+
     /// @brief Cache hit event handler.
     /// @details Updates the internal frequency sketches for the given item.
     /// @param item The item that has been hit.

--- a/include/cachemere/policy/insertion_tinylfu.hpp
+++ b/include/cachemere/policy/insertion_tinylfu.hpp
@@ -1,5 +1,11 @@
 namespace cachemere::policy {
 
+template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::clear()
+{
+    m_gatekeeper.clear();
+    m_frequency_sketch.clear();
+}
+
 template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::on_cache_hit(const CacheItem& item)
 {
     touch_item(item.m_key);

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -250,3 +250,22 @@ TYPED_TEST(CacheTest, Swap)
     EXPECT_TRUE(cache_odd->contains(4));
     EXPECT_FALSE(cache_even->contains(2));
 }
+
+TYPED_TEST(CacheTest, Clear)
+{
+    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
+
+    cache->find(1);
+    cache->find(2);
+
+    cache->insert(1, Point3D{1, 1, 1});
+    cache->insert(2, Point3D{2, 2, 2});
+
+    EXPECT_TRUE(cache->contains(1));
+    EXPECT_TRUE(cache->contains(2));
+
+    cache->clear();
+
+    EXPECT_FALSE(cache->contains(1));
+    EXPECT_FALSE(cache->contains(2));
+}

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <list>
+#include <atomic>
 #include <map>
 #include <random>
 #include <string>


### PR DESCRIPTION
* Adds `Cache::clear()` method for clearing everything at once.
* Fixes a swap bug where we were swapping `maximum_size` and `size` manually since we were under lock, but where the accessors for these attributes didn't take the lock, leading to possible race conditions
* Fixes a nasty ADL issue caused by the `ThreadSafe` template parameter not being specified in the `CacheType` type alias.

(No version number bump because I didn't tag the previous one yet. We'd need to automate that though)