### PR TITLE
Use a recursive mutex instead of a regular mutex on the threadsafe cache

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -142,7 +142,7 @@ public:
     [[nodiscard]] double byte_hit_rate() const;
 
 protected:
-    std::unique_lock<std::mutex> lock() const;
+    std::unique_lock<std::recursive_mutex> lock() const;
 
 private:
     using CacheItem = Item<Key, Value>;
@@ -166,8 +166,8 @@ private:
     MeasureKey   m_measure_key;
     MeasureValue m_measure_value;
 
-    mutable std::mutex m_mutex;
-    DataMap            m_data;
+    mutable std::recursive_mutex m_mutex;
+    DataMap                      m_data;
 
     mutable MeanAccumulator m_hit_rate_acc;
     mutable MeanAccumulator m_byte_hit_rate_acc;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "cachemere",
-    "version-semver": "0.1.1",
+    "version-semver": "0.1.2",
     "dependencies": [
         {
             "name": "vcpkg-cmake",


### PR DESCRIPTION
Turns out the fact that `std::unique_lock`  supports recursive locking doesn't mean that recursive locking works with `std::mutex` :smile: 

This allows derived caches to write new methods that do many operations (e.g. lookup & update) while holding a single lock without allowing the internals of the cache to be misused.