### PR TITLE
Add import construction and reduce copies on insert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ project(cachemere)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Boost REQUIRED)
+find_package(Boost 1.65 REQUIRED)
 
 add_library(cachemere INTERFACE)
 

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -348,14 +348,7 @@ void Cache<K, V, I, E, SV, SK, TS>::insert_or_update(K&& key, V&& value, size_t 
     auto key_and_item = m_data.find(key);
     if (key_and_item != m_data.end()) {
         // Update.
-
-        if (value_size > key_and_item->second.m_value_size) {
-            // This item got bigger with the update.
-            m_current_size += value_size - key_and_item->second.m_value_size;
-        } else {
-            // This item got smaller with the update.
-            m_current_size -= key_and_item->second.m_value_size - value_size;
-        }
+        m_current_size = m_current_size + key_and_item->second.m_value_size - value_size;
 
         key_and_item->second.m_value      = std::move(value);
         key_and_item->second.m_value_size = value_size;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "cachemere",
-    "version-semver": "0.1.3",
+    "version-semver": "0.1.4",
     "dependencies": [
         {
             "name": "vcpkg-cmake",


### PR DESCRIPTION
Import construction will allow us to create a cache with an initial item set, bypassing the opinion of the insertion policy. The copy improvements make it possible to insert an item with a single key copy and no value copy (down from two key copies and one value copy). 

It could be improved further to remove key copies altogether, but that's for another day!