### PR TITLE
Add support for parameterizing the cache constraint via a new policy.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,9 @@ jobs:
           VCPKG_ROOT: ./vcpkg
         shell: bash
         run: |
-          cmake -B build -S . -DUSE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -D CMAKE_BUILD_TYPE=Debug
-          cmake --build build/
+          cmake -B build -S . -DUSE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -D CMAKE_BUILD_TYPE=Debug || true
+          cmake --build build/ || true
+          cat build/vcpkg-manifest-install.log
 
       - name: Run Tests
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,8 @@ jobs:
           VCPKG_ROOT: ./vcpkg
         shell: bash
         run: |
-          cmake -B build -S . -DUSE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -D CMAKE_BUILD_TYPE=Debug || true
-          cmake --build build/ || true
-          cat build/vcpkg-manifest-install.log
+          cmake -B build -S . -DUSE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -D CMAKE_BUILD_TYPE=Debug
+          cmake --build build/
 
       - name: Run Tests
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,11 @@ target_sources(cachemere
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/presets.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/detail/traits.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/bind.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_count.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_count.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_memory.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_memory.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_lru.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_lru.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/eviction_gdsf.h>

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Cachemere is designed with the explicit goal of providing a single reusable cach
 ### Modular Policy Design
 
 Cachemere tackles this goal in a modular fashion with the concept of _policies_. A `cachemere::Cache` is parameterized
-by an **Insertion Policy** and an **Eviction Policy**.
+by a **Constraint Policy**, an **Insertion Policy**, and an **Eviction Policy**.
 
-Broadly speaking, the job of an **Insertion Policy** is to determine whether an item should be inserted or kept in cache, while the job of an **Eviction
+Broadly speaking, the job of the **Constraint Policy** is to determine whether an item _can_ be in the cache (e.g. if there is enough free space), the job of an **Insertion Policy** is to determine whether an item should be inserted or kept in cache, while the job of an **Eviction
 Policy** is to determine which item(s) should be evicted from the cache. The cache will query its policies when it has to make a
 decision on whether an item should be added or excluded.
 
@@ -76,5 +76,3 @@ policies can also be used with different cache implementations.
 For instance, instead of using more common policies like Least-Recently Used (LRU),
 a product might need to use a custom cache that takes the frequency of access as well as the size of the item into
 consideration when establishing which item to evict. To do this, one could implement a `SizeBasedEvictionPolicy` and use it with the existing `cachemere::Cache`.
-
-Similarly, imagine a cache that limits the amount of memory it uses. Now, imagine a use case that additionally requires constraining the number of items in the cache. To handle this scenario, you could implement a new Cache object parameterized by these two policies and reuse Cachemere's LRU policy with this Cache object.

--- a/benchmarks/accuracy/src/io_benchmark.cpp
+++ b/benchmarks/accuracy/src/io_benchmark.cpp
@@ -136,10 +136,10 @@ INSTANTIATE_TEST_SUITE_P(AccuracyBenchmark, CacheSizeFixture, testing::ValuesIn(
 
 TEST_P(CacheSizeFixture, IO_LRU)
 {
-    using LRUCache = cachemere::presets::LRUCache<std::string,
-                                                  std::shared_ptr<Article>,
-                                                  cachemere::measurement::Size<Article>,
-                                                  cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
+    using LRUCache = cachemere::presets::memory::LRUCache<std::string,
+                                                          std::shared_ptr<Article>,
+                                                          cachemere::measurement::Size<Article>,
+                                                          cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
 
     const uint32_t cache_size = GetParam();
     auto           cache      = std::make_shared<LRUCache>(cache_size);
@@ -148,10 +148,10 @@ TEST_P(CacheSizeFixture, IO_LRU)
 
 TEST_P(CacheSizeFixture, IO_TINYLFU)
 {
-    using TLFUCache = cachemere::presets::TinyLFUCache<std::string,
-                                                       std::shared_ptr<Article>,
-                                                       cachemere::measurement::Size<Article>,
-                                                       cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
+    using TLFUCache = cachemere::presets::memory::TinyLFUCache<std::string,
+                                                               std::shared_ptr<Article>,
+                                                               cachemere::measurement::Size<Article>,
+                                                               cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
 
     const uint32_t cache_size = GetParam();
     auto           cache      = std::make_shared<TLFUCache>(cache_size);
@@ -168,11 +168,11 @@ TEST_P(CacheSizeFixture, IO_GDSF_CONSTANT_COST)
         }
     };
 
-    using GDSFCache = cachemere::presets::CustomCostCache<std::string,
-                                                          std::shared_ptr<Article>,
-                                                          ConstantCost,
-                                                          cachemere::measurement::Size<Article>,
-                                                          cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
+    using GDSFCache = cachemere::presets::memory::CustomCostCache<std::string,
+                                                                  std::shared_ptr<Article>,
+                                                                  ConstantCost,
+                                                                  cachemere::measurement::Size<Article>,
+                                                                  cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
 
     const uint32_t cache_size = GetParam();
 
@@ -190,11 +190,11 @@ TEST_P(CacheSizeFixture, IO_GDSF_LATENCY_COST)
         }
     };
 
-    using GDSFCache = cachemere::presets::CustomCostCache<std::string,
-                                                          std::shared_ptr<Article>,
-                                                          QuadraticCost,
-                                                          cachemere::measurement::Size<Article>,
-                                                          cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
+    using GDSFCache = cachemere::presets::memory::CustomCostCache<std::string,
+                                                                  std::shared_ptr<Article>,
+                                                                  QuadraticCost,
+                                                                  cachemere::measurement::Size<Article>,
+                                                                  cachemere::measurement::CapacityDynamicallyAllocated<std::string>>;
 
     const uint32_t cache_size = GetParam();
 

--- a/benchmarks/performance/src/bench_cache.cpp
+++ b/benchmarks/performance/src/bench_cache.cpp
@@ -34,6 +34,7 @@ using BenchCache = Cache<std::string,
                          std::string,
                          I,
                          E,
+                         policy::ConstraintMemory,
                          measurement::CapacityDynamicallyAllocated<std::string>,
                          measurement::CapacityDynamicallyAllocated<std::string>,
                          ThreadSafe>;

--- a/implementingCustomPolicies.dox
+++ b/implementingCustomPolicies.dox
@@ -54,11 +54,6 @@ In addition to the shared requirements above, a constraint policy must implement
     satisfying the constraint.
     @note Returning `true` guarantees that the object matching the key will be updated.
 
-* `bool is_invalidated(const Key& key)`
-
-    Should return `true` if the value associated with `key` cannot be kept in cache while still satisfying the constraint.
-    @note Returning `true` guarantees that the object matching the key will be evicted from the cache.
-
 * `bool is_satisfied()`
 
     Should return `true` if the constraint is currently satisfied. The cache uses this method after a constraint update (e.g. a cache resize)

--- a/implementingCustomPolicies.dox
+++ b/implementingCustomPolicies.dox
@@ -46,13 +46,13 @@ In addition to the shared requirements above, a constraint policy must implement
 * `bool can_add(const Key& key, const Item<Value>& item)`
 
     Should return `true` if the item can be inserted in the cache while still satisfying the constraint.
-    @note Returning `true` does not guarantee that the object matching the key will be inserted in cache.
+    @note Returning `true` guarantees that the object matching the key will be inserted in cache.
 
 * `bool can_replace(const Key& key, const Item<Value>& old_item, const Item<Value>& new_item)`
 
     Should return `true` if the value associated with `key` can be changed from `old_item` to `new_item` while still
     satisfying the constraint.
-    @note Returning `true` does not guarantee that the object matching the key will be updated.
+    @note Returning `true` guarantees that the object matching the key will be updated.
 
 * `bool is_invalidated(const Key& key)`
 

--- a/implementingCustomPolicies.dox
+++ b/implementingCustomPolicies.dox
@@ -4,7 +4,7 @@ Implementing Custom Policies {#implementingCustomPolicies}
 This page is meant to guide you through the implementation of custom policies.
 ## Shared Characteristics
 ### Construction Requirements
-Both types of policies _must_ be [default-constructible](http://www.cplusplus.com/reference/type_traits/is_default_constructible/), because the cache is responsible for instanciating them.
+Insertion and eviction policies _must_ be [default-constructible](http://www.cplusplus.com/reference/type_traits/is_default_constructible/). The constraint policy may take parameters, these parameters will be forwarded to the policy from the cache constructor.
 ### Event Handlers
 The policies _may_ define the following event handlers to be notified of changes in the cache. These handlers do not all need to be implemented; a policy only needs to define the handlers that are relevant to its implementation. The cache will detect available handlers on its policies at compile-time, and will only call those that are defined.
 * `void on_insert(K& key, cachemere::detail::Item<V>& item)`
@@ -39,6 +39,31 @@ In addition, policies keeping references to values **must** swap the held refere
 ### Concurrency Requirements
 Policies do not need to take any steps to ensure thread-safety. The cache will properly protect policies to ensure no concurrent operations occur.
 
+## Constraint Policy
+
+In addition to the shared requirements above, a constraint policy must implement the following methods in order to be valid:
+
+* `bool can_add(const Key& key, const Item<Value>& item)`
+
+    Should return `true` if the item can be inserted in the cache while still satisfying the constraint.
+    @note Returning `true` does not guarantee that the object matching the key will be inserted in cache.
+
+* `bool can_replace(const Key& key, const Item<Value>& old_item, const Item<Value>& new_item)`
+
+    Should return `true` if the value associated with `key` can be changed from `old_item` to `new_item` while still
+    satisfying the constraint.
+    @note Returning `true` does not guarantee that the object matching the key will be updated.
+
+* `bool is_invalidated(const Key& key)`
+
+    Should return `true` if the value associated with `key` cannot be kept in cache while still satisfying the constraint.
+    @note Returning `true` guarantees that the object matching the key will be evicted from the cache.
+
+* `bool is_satisfied()`
+
+    Should return `true` if the constraint is currently satisfied. The cache uses this method after a constraint update (e.g. a cache resize)
+    to determine whether items should be evicted to make some room.
+
 ## Insertion Policy
 
 In addition to the shared requirements above, an insertion policy must implement the following methods in order to be valid:
@@ -51,7 +76,7 @@ In addition to the shared requirements above, an insertion policy must implement
 * `bool should_replace(const Key& victim, const Key& candidate)`
 
     Should return `true` if the policy states that the candidate should replace the victim in cache.
-    @note Returning `true` guarantees that the object matching the `candidate` key will be inserted in cache.
+    @note Returning `true` does not guarantee that the object matching the `candidate` key will be inserted in cache.
 
 ## Eviction Policy
 

--- a/include/cachemere.h
+++ b/include/cachemere.h
@@ -1,3 +1,8 @@
+#include "cachemere/policy/bind.h"
+
+#include "cachemere/policy/constraint_count.h"
+#include "cachemere/policy/constraint_memory.h"
+
 #include "cachemere/policy/eviction_lru.h"
 #include "cachemere/policy/eviction_gdsf.h"
 #include "cachemere/policy/eviction_segmented_lru.h"

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -139,11 +139,20 @@ public:
     /// @brief Get a reference to the insertion policy used by the cache.
     [[nodiscard]] MyInsertionPolicy& insertion_policy();
 
+    /// @brief Get a const reference to the insertion policy used by the cache.
+    [[nodiscard]] const MyInsertionPolicy& insertion_policy() const;
+
     /// @brief Get a reference to the eviction policy used by the cache.
     [[nodiscard]] MyEvictionPolicy& eviction_policy();
 
+    /// @brief Get a const reference to the eviction policy used by the cache.
+    [[nodiscard]] const MyEvictionPolicy& eviction_policy() const;
+
     /// @brief Get a reference to the constraint policy used by the cache.
     [[nodiscard]] MyConstraintPolicy& constraint_policy();
+
+    /// @brief Get a const reference to the constraint policy used by the cache.
+    [[nodiscard]] const MyConstraintPolicy& constraint_policy() const;
 
     /// @brief Compute and return the running hit rate of the cache.
     /// @details The hit rate is computed using a sliding window determined by the sliding window

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -2,10 +2,11 @@
 #define CACHEMERE_CACHE_H
 
 #include <cstdint>
-#include <map>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <unordered_map>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
@@ -26,6 +27,7 @@ namespace cachemere {
 /// @tparam Value The type of the items stored in the cache.
 /// @tparam InsertionPolicy A template parameterized by `Key` and `Value` implementing the insertion policy interface.
 /// @tparam EvictionPolicy A template parameterized by `Key` and `Value` implementing the eviction policy interface.
+/// @tparam ConstraintPolicy A template parameterized by `Key` and `Value` implementing the constraint policy interface.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
 /// @tparam ThreadSafe Whether to enable locking. When true, all cache operations will be protected by a lock. `true` by default.
@@ -35,27 +37,30 @@ template<typename Key,
          class InsertionPolicy,
          template<class, class>
          class EvictionPolicy,
+         template<class, class>
+         class ConstraintPolicy,
          typename MeasureValue = measurement::Size<Value>,
          typename MeasureKey   = measurement::Size<Key>,
          bool ThreadSafe       = true>
 class Cache
 {
 public:
-    using MyInsertionPolicy = InsertionPolicy<Key, Value>;
-    using MyEvictionPolicy  = EvictionPolicy<Key, Value>;
-    using CacheType         = Cache<Key, Value, InsertionPolicy, EvictionPolicy, MeasureValue, MeasureKey, ThreadSafe>;
+    using MyInsertionPolicy  = InsertionPolicy<Key, Value>;
+    using MyEvictionPolicy   = EvictionPolicy<Key, Value>;
+    using MyConstraintPolicy = ConstraintPolicy<Key, Value>;
+    using CacheType          = Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, ThreadSafe>;
 
     /// @brief Simple constructor.
-    /// @param maximum_size The maximum amount of memory to be used by the cache (in bytes).
-    /// @param statistics_window_size The length of the cache history to be kept for statistics.
-    Cache(size_t maximum_size, uint32_t statistics_window_size = 1000);
+    /// @param args Arguments to forward to the constraint policy constructor.
+    template<typename... Args> Cache(Args... args);
 
     /// @brief Constructor to initialize the cache with a set of items.
-    /// @details Will insert items in order in the cache until `maximum_size` is reached.
-    /// @param collection The collection to use to initialize the cache - must be either a map or a collection of pairs.
-    /// @param maximum_size The maximum amount of memory to be used by the cache (in bytes).
-    /// @param statistics_window_size The length of the cache history to be kept for statistics.
-    template<typename C> Cache(C& collection, size_t maximum_size, uint32_t statistics_window_size = 1000);
+    /// @details Will insert items in order in the cache as long as the constraint is satisfied.
+    /// @param collection The collection to use to initialize the cache - must be a collection of pairs.
+    /// @param args Tuple of arguments to forward to the constraint policy constructor.
+    /// @warning Items that are imported from the collection are moved out of the container and left
+    ///          in an unspecified state. The container itself can be reused after clearing it.
+    template<typename C, typename... Args> Cache(C& collection, std::tuple<Args...> args);
 
     /// @brief Check whether a given key is stored in the cache.
     /// @param key The key whose presence to test.
@@ -63,9 +68,11 @@ public:
     bool contains(const Key& key) const;
 
     /// @brief Find a given key in cache returning the associated value when it exists.
+    /// @details If the key exists in cache but is marked as invalidated by the constraint policy,
+    ///          it will be evicted from the cache immediately.
     /// @param key The key to lookup.
     /// @return The value if `key` is in cache, `std::nullopt` otherwise.
-    std::optional<Value> find(const Key& key) const;
+    std::optional<Value> find(const Key& key);
 
     /// @brief Copy the cache contents in the provided container.
     /// @details The container should conform to either of the STL's interfaces for associative
@@ -110,30 +117,20 @@ public:
     /// @return How many items are in cache.
     [[nodiscard]] size_t number_of_items() const;
 
-    /// @brief Get the amount of memory currently being used by cache items.
-    /// @details This method returns the amount of memory used by the cache. For every item,
-    ///          the cache stores the key and its value, along with an additional copy of the key.
-    ///          This brings the total memory used by an item to `2 * MeasureKey(key) + MeasureValue(value)`.
-    /// @return The current memory usage, in bytes.
-    [[nodiscard]] size_t size() const;
-
-    /// @brief Get the maximum amount of memory that can be used by the cache.
-    /// @details Once this size is reached, any future successful insertions will trigger
-    ///          evictions of one or more items.
-    /// @return The maximum size, in bytes.
-    [[nodiscard]] size_t maximum_size() const;
-
-    /// @brief Set the maximum amount of memory that can be used by the cache.
-    /// @details If the new maximum size is inferior to the maximum, the cache will resize itself and evict items
-    ///          until the new maximum is respected.
-    /// @param max_size The new maximum size, in bytes.
-    void set_maximum_size(size_t max_size);
+    /// @brief Update the cache constraint.
+    /// @details Forwards the update to the constraint and evicts items from the cache until the
+    ///          constraint is satisfied.
+    /// @param args Arguments to forward to the `Constraint::update()` .
+    template<typename... Args> void update_constraint(Args... args);
 
     /// @brief Get a reference to the insertion policy used by the cache.
     [[nodiscard]] MyInsertionPolicy& insertion_policy();
 
     /// @brief Get a reference to the eviction policy used by the cache.
     [[nodiscard]] MyEvictionPolicy& eviction_policy();
+
+    /// @brief Get a reference to the constraint policy used by the cache.
+    [[nodiscard]] MyConstraintPolicy& constraint_policy();
 
     /// @brief Compute and return the running hit rate of the cache.
     /// @details The hit rate is computed using a sliding window determined by the sliding window
@@ -148,28 +145,38 @@ public:
     /// @return The byte hit rate, in bytes.
     [[nodiscard]] double byte_hit_rate() const;
 
+    /// @brief Get the size of the sliding window used for computing statistics.
+    /// @return The size of the statistics sliding window.
+    [[nodiscard]] uint32_t statistics_window_size() const;
+
+    /// @brief Set the size of the sliding window used for computing statistics.
+    /// @warning This will reset the access log, so cache accesses made prior to calling this will not be
+    ///          counted in the statistics.
+    /// @param window_size The desired statistics window size.
+    void statistics_window_size(uint32_t window_size);
+
 protected:
     std::unique_lock<std::recursive_mutex> lock() const;
     template<typename C> void              import(C& collection);
 
 private:
     using CacheItem = Item<Value>;
-    using DataMap   = std::map<Key, CacheItem>;
+    using DataMap   = std::unordered_map<Key, CacheItem>;
     using DataMapIt = typename DataMap::iterator;
 
-    using MyInsertionPolicySP = std::unique_ptr<MyInsertionPolicy>;
-    using MyEvictionPolicySP  = std::unique_ptr<MyEvictionPolicy>;
+    using MyInsertionPolicySP  = std::unique_ptr<MyInsertionPolicy>;
+    using MyEvictionPolicySP   = std::unique_ptr<MyEvictionPolicy>;
+    using MyConstraintPolicySP = std::unique_ptr<MyConstraintPolicy>;
 
     using RollingMeanTag        = boost::accumulators::tag::rolling_mean;
     using RollingMeanStatistics = boost::accumulators::stats<RollingMeanTag>;
     using MeanAccumulator       = boost::accumulators::accumulator_set<uint32_t, RollingMeanStatistics>;
 
-    size_t   m_current_size;
-    size_t   m_maximum_size;
-    uint32_t m_statistics_window_size;
+    uint32_t m_statistics_window_size = 1000;
 
-    MyInsertionPolicySP m_insertion_policy;
-    MyEvictionPolicySP  m_eviction_policy;
+    MyInsertionPolicySP  m_insertion_policy;
+    MyEvictionPolicySP   m_eviction_policy;
+    MyConstraintPolicySP m_constraint_policy;
 
     MeasureKey   m_measure_key;
     MeasureValue m_measure_value;
@@ -180,20 +187,21 @@ private:
     mutable MeanAccumulator m_hit_rate_acc;
     mutable MeanAccumulator m_byte_hit_rate_acc;
 
-    bool   compare_evict(const Key& candidate_key, size_t candidate_size);
-    void   insert_or_update(Key&& key, Value&& value, size_t key_size, size_t value_size);
-    size_t free_amount(size_t amount_to_free);
-    void   remove(DataMapIt it);
+    bool check_insert(const Key& candidate_key, const CacheItem& item);
+    bool check_replace(const Key& candidate_key, const CacheItem& old_item, const CacheItem& new_item);
+
+    void insert_or_update(Key&& key, CacheItem&& value);
+    void remove(DataMapIt it);
 
     void on_insert(const Key& key, const CacheItem& item) const;
-    void on_update(const Key& key, const CacheItem& item) const;
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item) const;
     void on_cache_hit(const Key& key, const CacheItem& item) const;
     void on_cache_miss(const Key& key) const;
-    void on_evict(const Key& key) const;
+    void on_evict(const Key& key, const CacheItem& item) const;
 };
 
-template<typename K, typename V, template<class, class> class I, template<class, class> class E, typename SV, typename SK, bool TS>
-void swap(Cache<K, V, I, E, SV, SK, TS>& lhs, Cache<K, V, I, E, SV, SK, TS>& rhs);
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void swap(Cache<K, V, I, E, C, SV, SK, TS>& lhs, Cache<K, V, I, E, C, SV, SK, TS>& rhs);
 
 }  // namespace cachemere
 

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -7,13 +7,26 @@
 #include <mutex>
 #include <optional>
 #include <unordered_map>
+#include <vector>
+
+#ifdef _WIN32
+#    pragma warning(push)
+#    pragma warning(disable : 4244)
+#    pragma warning(disable : 4018)
+#endif
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
+#include <boost/hana.hpp>
+
+#ifdef _WIN32
+#    pragma warning(pop)
+#endif
 
 #include "item.h"
 #include "measurement.h"
+#include "detail/traits.h"
 
 /// @brief Root namespace
 namespace cachemere {

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -305,7 +305,7 @@ template<class K, class V, template<class, class> class I, template<class, class
 bool Cache<K, V, I, E, C, SV, SK, TS>::check_insert(const K& key, const CacheItem& item)
 {
     if (m_constraint_policy->can_add(key, item)) {
-        return true;
+        return m_insertion_policy->should_add(key);
     }
 
     // We need to perform some evictions to try and make some room.
@@ -417,7 +417,6 @@ void Cache<K, V, I, E, C, SV, SK, TS>::insert_or_update(K&& key, CacheItem&& ite
         on_update(key_and_item->first, item, key_and_item->second);
     } else {
         // Insert.
-        // const auto it_and_ok = m_data.emplace(std::piecewise_construct, std::forward_as_tuple(std::move(key)), std::move(item));
         const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(item));
         assert(it_and_ok.second);
         on_insert(it_and_ok.first->first, it_and_ok.first->second);

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -12,63 +12,75 @@ template<typename Key,
          class InsertionPolicy,
          template<class, class>
          class EvictionPolicy,
+         template<class, class>
+         class ConstraintPolicy,
          typename MeasureValue,
          typename MeasureKey,
          bool ThreadSafe>
-Cache<Key, Value, InsertionPolicy, EvictionPolicy, MeasureValue, MeasureKey, ThreadSafe>::Cache(size_t maximum_size, uint32_t statistics_window_size)
- : m_current_size{0},
-   m_maximum_size{maximum_size},
-   m_statistics_window_size{statistics_window_size},
-   m_insertion_policy(std::make_unique<InsertionPolicy<Key, Value>>()),
+template<typename... Args>
+Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, ThreadSafe>::Cache(Args... args)
+ : m_insertion_policy(std::make_unique<InsertionPolicy<Key, Value>>()),
    m_eviction_policy(std::make_unique<EvictionPolicy<Key, Value>>()),
-   m_measure_key{},
-   m_measure_value{},
+   m_constraint_policy(std::make_unique<ConstraintPolicy<Key, Value>>(std::forward<Args>(args)...)),
    m_mutex{},
    m_data{},
-   m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = statistics_window_size),
-   m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = statistics_window_size)
+   m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
+   m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
 {
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-template<typename C>
-Cache<K, V, I, E, SV, SK, TS>::Cache(C& collection, size_t maximum_size, uint32_t statistics_window_size) : Cache(maximum_size, statistics_window_size)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<typename Coll, typename... Args>
+Cache<K, V, I, E, C, SV, SK, TS>::Cache(Coll& collection, std::tuple<Args...> args)
+ : m_insertion_policy(std::make_unique<I<K, V>>()),
+   m_eviction_policy(std::make_unique<E<K, V>>()),
+   m_constraint_policy(
+       std::move(std::apply([](auto&&... params) { return std::make_unique<C<K, V>>(std::forward<decltype(params)>(params)...); }, std::move(args)))),
+   m_mutex{},
+   m_data{},
+   m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
+   m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
 {
     import(collection);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline bool Cache<K, V, I, E, SV, SK, TS>::contains(const K& key) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline bool Cache<K, V, I, E, C, SV, SK, TS>::contains(const K& key) const
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
     return m_data.find(key) != m_data.end();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-std::optional<V> Cache<K, V, I, E, SV, SK, TS>::find(const K& key) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
     auto key_and_item = m_data.find(key);
     if (key_and_item != m_data.end()) {
-        on_cache_hit(key_and_item->first, key_and_item->second);
-        return key_and_item->second.m_value;
+        if (!m_constraint_policy->is_invalidated(key)) {
+            on_cache_hit(key_and_item->first, key_and_item->second);
+            return key_and_item->second.m_value;
+        }
+
+        // The constraint policy says this item cannot be in cache anymore, so we remove it and act as if we just had a cache miss.
+        remove(key_and_item);
     }
 
     on_cache_miss(key);
     return std::nullopt;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-template<class C>
-void Cache<K, V, I, E, SV, SK, TS>::collect_into(C& container) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class Container>
+void Cache<K, V, I, E, C, SV, SK, TS>::collect_into(Container& container) const
 {
     using namespace boost;
     using namespace detail;
 
     // Use emplace_back if container is a sequence container, or emplace if container is an associative container.
     constexpr auto emplace_fn = hana::if_(
-        traits::stl::has_emplace_back<C, K, V>,
+        traits::stl::has_emplace_back<Container, K, V>,
         [](auto& seq_container, const auto& key, const auto& item) { seq_container.emplace_back(key, item.m_value); },
         [](auto& assoc_container, const auto& key, const auto& item) { assoc_container.emplace(key, item.m_value); });
 
@@ -76,7 +88,7 @@ void Cache<K, V, I, E, SV, SK, TS>::collect_into(C& container) const
 
     // Reserve space if the container has a reserve() method and a size method().
     hana::if_(
-        hana::and_(traits::stl::has_reserve<C>, traits::stl::has_size<C>),
+        hana::and_(traits::stl::has_reserve<Container>, traits::stl::has_size<Container>),
         [&](auto& c) { c.reserve(c.size() + m_data.size()); },
         [](auto&) {})(container);
 
@@ -86,27 +98,38 @@ void Cache<K, V, I, E, SV, SK, TS>::collect_into(C& container) const
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, SV, SK, TS>::insert(K key, V value)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+bool Cache<K, V, I, E, C, SV, SK, TS>::insert(K key, V value)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
-    const auto   key_size           = static_cast<size_t>(m_measure_key(key));
-    const auto   value_size         = static_cast<size_t>(m_measure_value(value));
-    const size_t item_size          = key_size + value_size;
-    const size_t item_size_overhead = item_size + key_size;
+    const auto key_size   = static_cast<size_t>(m_measure_key(key));
+    const auto value_size = static_cast<size_t>(m_measure_value(value));
 
-    const bool should_insert = compare_evict(key, item_size_overhead);
+    CacheItem new_item{key_size, std::move(value), value_size};
 
-    if (should_insert) {
-        insert_or_update(std::move(key), std::move(value), key_size, value_size);
+    auto it = m_data.find(key);
+    if (it != m_data.end()) {
+        if (check_replace(key, it->second, new_item)) {
+            // We call insert_or_update because we might have evicted the original key to make room for this one.
+            insert_or_update(std::move(key), std::move(new_item));
+            return true;
+        }
+    } else {
+        if (check_insert(key, new_item)) {
+            const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(new_item));
+            assert(it_and_ok.second);
+
+            on_insert(it_and_ok.first->first, it_and_ok.first->second);
+            return true;
+        }
     }
 
-    return should_insert;
+    return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, SV, SK, TS>::remove(const K& key)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+bool Cache<K, V, I, E, C, SV, SK, TS>::remove(const K& key)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
@@ -118,12 +141,11 @@ bool Cache<K, V, I, E, SV, SK, TS>::remove(const K& key)
     return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::clear()
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::clear()
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
-    m_current_size = 0;
     m_data.clear();
 
     m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
@@ -131,11 +153,12 @@ void Cache<K, V, I, E, SV, SK, TS>::clear()
 
     m_insertion_policy->clear();
     m_eviction_policy->clear();
+    m_constraint_policy->clear();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
 template<class P>
-void Cache<K, V, I, E, SV, SK, TS>::retain(P predicate_fn)
+void Cache<K, V, I, E, C, SV, SK, TS>::retain(P predicate_fn)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
@@ -150,8 +173,8 @@ void Cache<K, V, I, E, SV, SK, TS>::retain(P predicate_fn)
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::swap(CacheType& other)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::swap(CacheType& other)
 {
     // Acquire both cache locks.
     std::unique_lock<std::recursive_mutex> me_guard(lock());
@@ -159,15 +182,11 @@ void Cache<K, V, I, E, SV, SK, TS>::swap(CacheType& other)
 
     using std::swap;
 
-    swap(m_current_size, other.m_current_size);
-    swap(m_maximum_size, other.m_maximum_size);
     swap(m_statistics_window_size, other.m_statistics_window_size);
 
     swap(m_insertion_policy, other.m_insertion_policy);
     swap(m_eviction_policy, other.m_eviction_policy);
-
-    swap(m_measure_key, other.m_measure_key);
-    swap(m_measure_value, other.m_measure_value);
+    swap(m_constraint_policy, other.m_constraint_policy);
 
     swap(m_data, other.m_data);
 
@@ -175,68 +194,84 @@ void Cache<K, V, I, E, SV, SK, TS>::swap(CacheType& other)
     swap(m_byte_hit_rate_acc, other.m_byte_hit_rate_acc);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline size_t Cache<K, V, I, E, SV, SK, TS>::number_of_items() const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline size_t Cache<K, V, I, E, C, SV, SK, TS>::number_of_items() const
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
     return m_data.size();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline size_t Cache<K, V, I, E, SV, SK, TS>::size() const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<typename... Args>
+void Cache<K, V, I, E, C, SV, SK, TS>::update_constraint(Args... args)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
-    return m_current_size;
-}
+    m_constraint_policy->update(std::forward<Args>(args)...);
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline size_t Cache<K, V, I, E, SV, SK, TS>::maximum_size() const
-{
-    std::unique_lock<std::recursive_mutex> guard(lock());
-    return m_maximum_size;
-}
+    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !m_constraint_policy->is_satisfied(); };
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline void Cache<K, V, I, E, SV, SK, TS>::set_maximum_size(size_t max_size)
-{
-    std::unique_lock<std::recursive_mutex> guard(lock());
-    m_maximum_size = max_size;
+    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); victim_it = m_eviction_policy->victim_begin()) {
+        const K& key_to_evict = *victim_it;
+        auto     key_and_item = m_data.find(key_to_evict);
 
-    if (m_maximum_size < m_current_size) {
-        const size_t                  amount_to_free = m_current_size - m_maximum_size;
-        [[maybe_unused]] const size_t amount_freed   = free_amount(amount_to_free);
-
-        assert(amount_freed >= amount_to_free);
+        if (key_and_item != m_data.end()) {
+            remove(key_and_item);
+        } else {
+            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
+            assert(false);
+        }
     }
-    assert(m_current_size <= m_maximum_size);
+
+    assert(m_constraint_policy->is_satisfied());
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline I<K, V>& Cache<K, V, I, E, SV, SK, TS>::insertion_policy()
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline I<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::insertion_policy()
 {
     return *m_insertion_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline E<K, V>& Cache<K, V, I, E, SV, SK, TS>::eviction_policy()
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline E<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::eviction_policy()
 {
     return *m_eviction_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline double Cache<K, V, I, E, SV, SK, TS>::hit_rate() const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline C<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::constraint_policy()
+{
+    return *m_constraint_policy;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline double Cache<K, V, I, E, C, SV, SK, TS>::hit_rate() const
 {
     return boost::accumulators::rolling_mean(m_hit_rate_acc);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-inline double Cache<K, V, I, E, SV, SK, TS>::byte_hit_rate() const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline double Cache<K, V, I, E, C, SV, SK, TS>::byte_hit_rate() const
 {
     return boost::accumulators::rolling_mean(m_byte_hit_rate_acc);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-std::unique_lock<std::recursive_mutex> Cache<K, V, I, E, SV, SK, TS>::lock() const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline uint32_t Cache<K, V, I, E, C, SV, SK, TS>::statistics_window_size() const
+{
+    return m_statistics_window_size;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline void Cache<K, V, I, E, C, SV, SK, TS>::statistics_window_size(uint32_t window_size)
+{
+    m_statistics_window_size = window_size;
+
+    m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+    m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+std::unique_lock<std::recursive_mutex> Cache<K, V, I, E, C, SV, SK, TS>::lock() const
 {
     if constexpr (TS) {
         std::unique_lock<std::recursive_mutex> guard{m_mutex};
@@ -247,163 +282,157 @@ std::unique_lock<std::recursive_mutex> Cache<K, V, I, E, SV, SK, TS>::lock() con
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-template<class C>
-void Cache<K, V, I, E, SV, SK, TS>::import(C& collection)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class Coll>
+void Cache<K, V, I, E, C, SV, SK, TS>::import(Coll& collection)
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 
     for (auto& [key, value] : collection) {
-        const auto   key_size           = static_cast<size_t>(m_measure_key(key));
-        const auto   value_size         = static_cast<size_t>(m_measure_value(value));
-        const size_t item_size          = key_size + value_size;
-        const size_t item_size_overhead = item_size + key_size;
+        const auto key_size   = static_cast<size_t>(m_measure_key(key));
+        const auto value_size = static_cast<size_t>(m_measure_value(value));
+        CacheItem  item{key_size, std::move(value), value_size};
 
-        if (m_current_size + item_size_overhead > m_maximum_size) {
+        if (!m_constraint_policy->can_add(key, item)) {
             return;
         }
 
-        insert_or_update(std::move(key), std::move(value), key_size, value_size);
+        insert_or_update(std::move(key), std::move(item));
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, SV, SK, TS>::compare_evict(const K& candidate_key, size_t candidate_size)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+bool Cache<K, V, I, E, C, SV, SK, TS>::check_insert(const K& key, const CacheItem& item)
 {
-    if (m_current_size + candidate_size <= m_maximum_size) {
-        // We have enough room. Insert if the policy agrees.
-        return m_insertion_policy->should_add(candidate_key);
-    } else {
-        if (candidate_size > m_maximum_size) {
-            // The item to insert/update is bigger than the maximum size of the cache, no need to attempt an insertion.
-            return false;
-        }
-        // We need to get a list of keys to evict to make room for the candidate. Since we restrict cache inserts by
-        // cache size instead of by nb. of items, we might evict multiple items to insert one. This is bad because it
-        // leads to inaccuracies:
-        //
-        // Say for instance we want to insert a 4 kb item. In order to insert it,
-        // we might need to evict 4 1kb items.
-        // Since this is a feedback cache, insertion policies operate by comparing two keys (the candidate and an
-        // eviction victim) together and inserting/keeping the best one. This means that in order to insert our 4kb
-        // item, we'd need to make 4 calls to the insertion policy, and insert the item only if all 4 calls come out
-        // positive. *However*, this only establishes that the candidate is better than each individual replaced item,
-        // not that it is better than the sum of them... This could be solved in two ways.
-        //
-        // The easiest way to fix the issue would be to change the cache constraint from "allocated memory" to "number
-        // of cached items". This would lead to some inaccuracies in how memory is tracked, it but would
-        // increase the performance of the cache (an insert would always evict [0,1] item).
-        //
-        // The harder way would be to change the interface of the insertion policy. Instead of should_replace(Key&,
-        // Key&), we could do should_replace(Key&, vector<Key&>). This would allow the insertion policy to weigh the
-        // candidate vs. *all* the evicted keys. (e.g. an LFU policy could make sure that the load counts of the
-        // candidate needs to be higher than the _sum_ of load counts of all victims) I consider this method the harder
-        // one because it would make the implementation of all insertion policies considerably harder. (it's not always
-        // trivial to determine whether a key is a better candidate than a given set of keys)
-        //
-        // Those two ways could even be used together: we could change the insertion policy interface *and* provide a
-        // new count-limited cache for improved performance, while keeping the memory-limited cache for when required.
-
-        std::vector<DataMapIt> keys_to_evict;
-        size_t                 freed_amount = 0;
-
-        auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && freed_amount <= candidate_size; };
-
-        for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); ++victim_it) {
-            const K& key_to_evict = *victim_it;
-            auto     key_and_item = m_data.find(key_to_evict);
-
-            if (key_and_item != m_data.end()) {
-                if (!m_insertion_policy->should_replace(key_to_evict, candidate_key)) {
-                    return false;
-                }
-                const auto total_size_and_overhead = key_and_item->second.m_key_size + key_and_item->second.m_total_size;
-                freed_amount += total_size_and_overhead;
-                keys_to_evict.push_back(key_and_item);
-            } else {
-                // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the
-                // cache are out of sync.
-                assert(false);
-            }
-        }
-
-        // If this trips, something is very wrong with how size is tracked.
-        // This means that evicting all items didn't free enough space in the cache for the candidate,
-        // yet the check at the beginning of this method ensures that the new item is smaller than
-        // the max size of the cache...
-        assert((m_current_size - freed_amount) + candidate_size <= m_maximum_size);
-
-        // Perform the eviction(s).
-        for (auto key_and_item : keys_to_evict) {
-            remove(key_and_item);
-        }
-
+    if (m_constraint_policy->can_add(key, item)) {
         return true;
     }
-}
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::insert_or_update(K&& key, V&& value, size_t key_size, size_t value_size)
-{
-    auto key_and_item = m_data.find(key);
-    if (key_and_item != m_data.end()) {
-        // Update.
-        m_current_size = m_current_size + key_and_item->second.m_value_size - value_size;
+    // We need to perform some evictions to try and make some room.
+    // Since the insertion process can fail at anytime before we know how many keys to evict (e.g. if should_replace was to return false) however,
+    // we can't directly evict items as we go. To fix this, we copy the constraint policy to see how many keys we'd have to evict. If we manage to
+    // satisfy the constraint copy, we evict the keys we picked and proceed with the insertion.
+    auto                   constraint_copy = std::make_unique<MyConstraintPolicy>(*m_constraint_policy);
+    std::vector<DataMapIt> keys_to_evict;
 
-        key_and_item->second.m_value      = std::move(value);
-        key_and_item->second.m_value_size = value_size;
-        key_and_item->second.m_total_size = key_size + value_size;
+    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !constraint_copy->can_add(key, item); };
 
-        on_update(key_and_item->first, key_and_item->second);
-    } else {
-        // Insert.
-        const auto it_and_ok =
-            m_data.emplace(std::piecewise_construct, std::forward_as_tuple(std::move(key)), std::forward_as_tuple(key_size, std::move(value), value_size));
-        assert(it_and_ok.second);
-
-        on_insert(it_and_ok.first->first, it_and_ok.first->second);
-
-        m_current_size += key_size + key_size + value_size;
-    }
-}
-
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-size_t Cache<K, V, I, E, SV, SK, TS>::free_amount(size_t amount_to_free)
-{
-    assert(amount_to_free <= m_current_size);
-    size_t freed_amount = 0;
-
-    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && freed_amount <= amount_to_free; };
-
-    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); victim_it = m_eviction_policy->victim_begin()) {
+    // As long as the constraint isn't satisfied, we keep evicting keys.
+    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); ++victim_it) {
         const K& key_to_evict = *victim_it;
         auto     key_and_item = m_data.find(key_to_evict);
 
         if (key_and_item != m_data.end()) {
-            auto total_size_and_overhead = key_and_item->second.m_key_size + key_and_item->second.m_total_size;
-            freed_amount += total_size_and_overhead;
-            remove(key_and_item);
+            if (!m_insertion_policy->should_replace(key_to_evict, key)) {
+                // This key to evict is considered "better" to have in cache than the item to be inserted.
+                // In this case, we abort the insertion.
+                return false;
+            }
+
+            constraint_copy->on_evict(key_and_item->first, key_and_item->second);
+            keys_to_evict.push_back(key_and_item);
         } else {
-            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
+            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the
+            // cache are out of sync.
             assert(false);
         }
     }
 
-    return freed_amount;
+    if (constraint_copy->can_add(key, item)) {
+        // The constraint is happy with that, so we actually evict the collected keys.
+        for (auto key_and_item : keys_to_evict) {
+            remove(key_and_item);
+        }
+        return true;
+    }
+
+    return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::remove(DataMapIt it)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+bool Cache<K, V, I, E, C, SV, SK, TS>::check_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item)
 {
-    const auto total_size_and_overhead = it->second.m_key_size + it->second.m_total_size;
-    m_current_size -= total_size_and_overhead;
+    if (m_constraint_policy->can_replace(key, old_item, new_item)) {
+        return true;
+    }
 
-    on_evict(it->first);
+    // The logic here is very similar to check_insert but with an important modification.
+    // Since in this code path we're updating an existing key instead of adding a new one, we need to handle the case
+    // where the eviction policy recommends the eviction of the key we're trying to insert. If this happens and the constraint
+    // is still not satisfied afterwards, we need to treat all subsequent constraint checks as if we were inserting instead of updating our key
+    // (because the original was evicted).
+    auto constraint_copy      = std::make_unique<MyConstraintPolicy>(*m_constraint_policy);
+    bool evicted_original_key = false;
+
+    auto can_replace = [&]() {
+        if (evicted_original_key) {
+            return constraint_copy->can_add(key, new_item);
+        } else {
+            return constraint_copy->can_replace(key, old_item, new_item);
+        }
+    };
+
+    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !can_replace(); };
+
+    // Evict until the constraint copy is happy.
+    std::vector<DataMapIt> keys_to_evict;
+
+    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); ++victim_it) {
+        const K& key_to_evict = *victim_it;
+        auto     key_and_item = m_data.find(key_to_evict);
+
+        if (key_and_item != m_data.end()) {
+            if (!m_insertion_policy->should_replace(key_to_evict, key)) {
+                return false;
+            }
+
+            evicted_original_key |= key_and_item->first == key;
+
+            constraint_copy->on_evict(key_and_item->first, key_and_item->second);
+            keys_to_evict.push_back(key_and_item);
+        } else {
+            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the
+            // cache are out of sync.
+            assert(false);
+        }
+    }
+
+    if (can_replace()) {
+        for (auto key_and_item : keys_to_evict) {
+            remove(key_and_item);
+        }
+        return true;
+    }
+
+    return false;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::insert_or_update(K&& key, CacheItem&& item)
+{
+    auto key_and_item = m_data.find(key);
+    if (key_and_item != m_data.end()) {
+        using std::swap;
+        swap(key_and_item->second, item);
+        on_update(key_and_item->first, item, key_and_item->second);
+    } else {
+        // Insert.
+        // const auto it_and_ok = m_data.emplace(std::piecewise_construct, std::forward_as_tuple(std::move(key)), std::move(item));
+        const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(item));
+        assert(it_and_ok.second);
+        on_insert(it_and_ok.first->first, it_and_ok.first->second);
+    }
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::remove(DataMapIt it)
+{
+    on_evict(it->first, it->second);
     m_data.erase(it);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::on_insert(const K& key, const CacheItem& item) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::on_insert(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
@@ -415,25 +444,35 @@ void Cache<K, V, I, E, SV, SK, TS>::on_insert(const K& key, const CacheItem& ite
         detail::traits::event::has_on_insert<K, V, E>,
         [&](auto& x) { return x.on_insert(key, item); },
         [](auto&) {})(*m_eviction_policy);
+
+    boost::hana::if_(
+        detail::traits::event::has_on_insert<K, V, C>,
+        [&](auto& x) { return x.on_insert(key, item); },
+        [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::on_update(const K& key, const CacheItem& item) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::on_update(const K& key, const CacheItem& old_item, const CacheItem& new_item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
         detail::traits::event::has_on_update<K, V, I>,
-        [&](auto& x) { return x.on_update(key, item); },
+        [&](auto& x) { return x.on_update(key, old_item, new_item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
         detail::traits::event::has_on_update<K, V, E>,
-        [&](auto& x) { return x.on_update(key, item); },
+        [&](auto& x) { return x.on_update(key, old_item, new_item); },
         [](auto&) {})(*m_eviction_policy);
+
+    boost::hana::if_(
+        detail::traits::event::has_on_update<K, V, C>,
+        [&](auto& x) { return x.on_update(key, old_item, new_item); },
+        [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::on_cache_hit(const K& key, const CacheItem& item) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_hit(const K& key, const CacheItem& item) const
 {
     // Update the cache hit rate accumulators.
     m_hit_rate_acc(1);
@@ -449,10 +488,15 @@ void Cache<K, V, I, E, SV, SK, TS>::on_cache_hit(const K& key, const CacheItem& 
         detail::traits::event::has_on_cachehit<K, V, E>,
         [&](auto& x) { return x.on_cache_hit(key, item); },
         [](auto&) {})(*m_eviction_policy);
+
+    boost::hana::if_(
+        detail::traits::event::has_on_cachehit<K, V, E>,
+        [&](auto& x) { return x.on_cache_hit(key, item); },
+        [](auto&) {})(*m_eviction_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::on_cache_miss(const K& key) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_miss(const K& key) const
 {
     // Update the cache hit rate accumulators.
     m_hit_rate_acc(0);
@@ -468,25 +512,35 @@ void Cache<K, V, I, E, SV, SK, TS>::on_cache_miss(const K& key) const
         detail::traits::event::has_on_cachemiss<K, V, E>,
         [&](auto& x) { return x.on_cache_miss(key); },
         [](auto&) {})(*m_eviction_policy);
+
+    boost::hana::if_(
+        detail::traits::event::has_on_cachemiss<K, V, C>,
+        [&](auto& x) { return x.on_cache_miss(key); },
+        [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void Cache<K, V, I, E, SV, SK, TS>::on_evict(const K& key) const
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void Cache<K, V, I, E, C, SV, SK, TS>::on_evict(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
         detail::traits::event::has_on_evict<K, V, I>,
-        [&](auto& x) { return x.on_evict(key); },
+        [&](auto& x) { return x.on_evict(key, item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
         detail::traits::event::has_on_evict<K, V, E>,
-        [&](auto& x) { return x.on_evict(key); },
+        [&](auto& x) { return x.on_evict(key, item); },
         [](auto&) {})(*m_eviction_policy);
+
+    boost::hana::if_(
+        detail::traits::event::has_on_evict<K, V, C>,
+        [&](auto& x) { return x.on_evict(key, item); },
+        [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, class SV, class SK, bool TS>
-void swap(Cache<K, V, I, E, SV, SK, TS>& lhs, Cache<K, V, I, E, SV, SK, TS>& rhs)
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+void swap(Cache<K, V, I, E, C, SV, SK, TS>& lhs, Cache<K, V, I, E, C, SV, SK, TS>& rhs)
 {
     lhs.swap(rhs);
 }

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -226,13 +226,31 @@ inline I<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::insertion_policy()
 }
 
 template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline const I<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::insertion_policy() const
+{
+    return *m_insertion_policy;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
 inline E<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::eviction_policy()
 {
     return *m_eviction_policy;
 }
 
 template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline const E<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::eviction_policy() const
+{
+    return *m_eviction_policy;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
 inline C<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::constraint_policy()
+{
+    return *m_constraint_policy;
+}
+
+template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+inline const C<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::constraint_policy() const
 {
     return *m_constraint_policy;
 }

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -52,13 +52,8 @@ std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key)
 
     auto key_and_item = m_data.find(key);
     if (key_and_item != m_data.end()) {
-        if (!m_constraint_policy->is_invalidated(key)) {
-            on_cache_hit(key_and_item->first, key_and_item->second);
-            return key_and_item->second.m_value;
-        }
-
-        // The constraint policy says this item cannot be in cache anymore, so we remove it and act as if we just had a cache miss.
-        remove(key_and_item);
+        on_cache_hit(key_and_item->first, key_and_item->second);
+        return key_and_item->second.m_value;
     }
 
     on_cache_miss(key);

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -1,9 +1,3 @@
-#include <vector>
-
-#include <boost/hana.hpp>
-
-#include "detail/traits.h"
-
 namespace cachemere {
 
 template<typename Key,

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -398,7 +398,9 @@ bool Cache<K, V, I, E, C, SV, SK, TS>::check_replace(const K& key, const CacheIt
                 return false;
             }
 
-            evicted_original_key |= key_and_item->first == key;
+            if (!evicted_original_key) {
+                evicted_original_key = key_and_item->first == key;
+            }
 
             constraint_copy->on_evict(key_and_item->first, key_and_item->second);
             keys_to_evict.push_back(key_and_item);

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -33,6 +33,7 @@ constexpr auto has_on_insert = boost::hana::is_valid(
 template<typename K, typename V, template<class, class> typename P>
 constexpr auto has_on_update = boost::hana::is_valid(
     [](auto& policy_t, auto& key_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_update(boost::hana::traits::declval(key_t),
+                                                                                                               boost::hana::traits::declval(item_t),
                                                                                                                boost::hana::traits::declval(item_t))) {
     })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
@@ -48,9 +49,10 @@ constexpr auto has_on_cachemiss = boost::hana::is_valid(
     })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>);
 
 template<typename K, typename V, template<class, class> typename P>
-constexpr auto has_on_evict =
-    boost::hana::is_valid([](auto& policy_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_evict(boost::hana::traits::declval(item_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>);
+constexpr auto has_on_evict = boost::hana::is_valid(
+    [](auto& policy_t, auto& key_t, auto& value_t) -> decltype(boost::hana::traits::declval(policy_t).on_evict(boost::hana::traits::declval(key_t),
+                                                                                                               boost::hana::traits::declval(value_t))) {
+    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
 }  // namespace event
 

--- a/include/cachemere/item.h
+++ b/include/cachemere/item.h
@@ -14,8 +14,10 @@ template<typename Value> struct Item {
        m_total_size{key_size + value_size}
     {
     }
-    Item(const Item& p_Other) = delete;
+    Item(Item&& other)      = default;
+    Item(const Item& other) = delete;
     Item& operator=(const Item&) = delete;
+    Item& operator=(Item&&) = default;
 
     size_t m_key_size;  //!< The size of the key.
 

--- a/include/cachemere/policy/bind.h
+++ b/include/cachemere/policy/bind.h
@@ -1,0 +1,13 @@
+#ifndef CACHEMERE_POLICY_BIND_H
+#define CACHEMERE_POLICY_BIND_H
+
+namespace cachemere::policy {
+
+/// @brief Binds a `Policy<K, V, Args...>` template to a `Policy<K, V>` template to be used with the cache.
+template<template<typename...> class Policy, typename... Args> struct bind {
+    template<typename K, typename V> using ttype = Policy<K, V, Args...>;
+};
+
+}  // namespace cachemere::policy
+
+#endif

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -1,0 +1,82 @@
+#ifndef CACHEMERE_CONSTRAINT_COUNT_H
+#define CACHEMERE_CONSTRAINT_COUNT_H
+
+#include "cachemere/item.h"
+
+namespace cachemere::policy {
+
+/// @brief Count constraint.
+/// @details Use this when the constraint of the cache should be the number of items in cache.
+/// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam Value The type of the values stored in the cache.
+template<typename Key, typename Value> class ConstraintCount
+{
+    using CacheItem = Item<Value>;
+
+public:
+    explicit ConstraintCount(size_t maximum_count);
+
+    /// @brief Clears the policy.
+    void clear();
+
+    /// @brief Determines whether an insertion candidate can be added into the cache.
+    /// @details That is, whether the constraint would still be satisfied after inserting the candidate.
+    /// @param key The key of the insertion candidate.
+    /// @param item The candidate item.
+    /// @return Whether the item can be added in cache.
+    [[nodiscard]] bool can_add(const Key& key, const CacheItem& item);
+
+    /// @brief Determines whether an item already in cache can be updated.
+    /// @details That is, whether the key can be updated to the new value while still satisfying the constraint.
+    /// @param key The key to be updated.
+    /// @param old_item The current value of the key in cache.
+    /// @param new_item The value that would replace the current value.
+    /// @return Whether the item can be replaced.
+    [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+
+    /// @brief Returns whether a key being looked up in cache still satisfies the constraint.
+    /// @details For this constraint, can_find always returns true because an item cannot become invalidated.
+    /// @param key The key of the insertion candidate.
+    /// @return Whether the key is still valid.
+    [[nodiscard]] bool is_invalidated(const Key& key);
+
+    /// @brief Returns whether the constraint is satisfied.
+    /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
+    /// @return Whether the cache constraint is satisfied.
+    [[nodiscard]] bool is_satisfied();
+
+    /// @brief Update the cache constraint.
+    /// @details Sets a new maximum count.
+    /// @param maximum_count The new number of items in cache.
+    void update(size_t maximum_count);
+
+    /// @brief Insertion event handler.
+    /// @details Adds one to the number of items in cache.
+    /// @param key The key of the inserted item.
+    /// @param item The item that has been inserted in cache.
+    void on_insert(const Key& key, const CacheItem& item);
+
+    /// @brief Eviction event handler.
+    /// @details Removes one from the number of items in cache.
+    /// @param key The key that was evicted.
+    /// @param item The item that was evicted.
+    void on_evict(const Key& key, const CacheItem& item);
+
+    /// @brief Get the number of items currently in the cache.
+    /// @return The number of items in cache.
+    size_t count() const;
+
+    /// @brief Get the maximum number of items allowed in cache.
+    /// @return The maximum number of items allowed in cache.
+    size_t maximum_count() const;
+
+private:
+    size_t m_maximum_count;
+    size_t m_count = 0;
+};
+
+}  // namespace cachemere::policy
+
+#include "constraint_count.hpp"
+
+#endif

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -34,12 +34,6 @@ public:
     /// @return Whether the item can be replaced.
     [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
-    /// @brief Returns whether a key being looked up in cache still satisfies the constraint.
-    /// @details For this constraint, can_find always returns true because an item cannot become invalidated.
-    /// @param key The key of the insertion candidate.
-    /// @return Whether the key is still valid.
-    [[nodiscard]] bool is_invalidated(const Key& key);
-
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
     /// @return Whether the cache constraint is satisfied.

--- a/include/cachemere/policy/constraint_count.hpp
+++ b/include/cachemere/policy/constraint_count.hpp
@@ -23,11 +23,6 @@ template<typename K, typename V> bool ConstraintCount<K, V>::can_replace(const K
     return true;
 }
 
-template<typename K, typename V> bool ConstraintCount<K, V>::is_invalidated(const K& /* key */)
-{
-    return false;
-}
-
 template<typename K, typename V> bool ConstraintCount<K, V>::is_satisfied()
 {
     return m_count <= m_maximum_count;

--- a/include/cachemere/policy/constraint_count.hpp
+++ b/include/cachemere/policy/constraint_count.hpp
@@ -1,0 +1,62 @@
+namespace cachemere::policy {
+
+template<typename K, typename V> ConstraintCount<K, V>::ConstraintCount(size_t maximum_count)
+{
+    update(maximum_count);
+}
+
+template<typename K, typename V> void ConstraintCount<K, V>::clear()
+{
+    m_count = 0;
+}
+
+template<typename K, typename V> bool ConstraintCount<K, V>::can_add(const K& /* key */, const CacheItem& /* item */)
+{
+    return m_count < m_maximum_count;
+}
+
+template<typename K, typename V> bool ConstraintCount<K, V>::can_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */)
+{
+    assert(m_count > 0);
+
+    // Replacement doesn't change the count, so it's always allowed.
+    return true;
+}
+
+template<typename K, typename V> bool ConstraintCount<K, V>::is_invalidated(const K& /* key */)
+{
+    return false;
+}
+
+template<typename K, typename V> bool ConstraintCount<K, V>::is_satisfied()
+{
+    return m_count <= m_maximum_count;
+}
+
+template<typename K, typename V> void ConstraintCount<K, V>::update(size_t maximum_count)
+{
+    m_maximum_count = maximum_count;
+}
+
+template<typename K, typename V> void ConstraintCount<K, V>::on_insert(const K& /* key */, const CacheItem& /* item */)
+{
+    ++m_count;
+}
+
+template<typename K, typename V> void ConstraintCount<K, V>::on_evict(const K& /* key */, const CacheItem& /* item */)
+{
+    assert(m_count > 0);
+    --m_count;
+}
+
+template<typename K, typename V> size_t ConstraintCount<K, V>::count() const
+{
+    return m_count;
+}
+
+template<typename K, typename V> size_t ConstraintCount<K, V>::maximum_count() const
+{
+    return m_maximum_count;
+}
+
+}  // namespace cachemere::policy

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -1,0 +1,91 @@
+#ifndef CACHEMERE_CONSTRAINT_MEMORY_H
+#define CACHEMERE_CONSTRAINT_MEMORY_H
+
+#include "cachemere/item.h"
+
+namespace cachemere::policy {
+
+/// @brief Memory constraint.
+/// @details Use this when the constraint of the cache should be how many bytes of memory it uses.
+/// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam Value The type of the values stored in the cache.
+template<typename Key, typename Value> class ConstraintMemory
+{
+    using CacheItem = Item<Value>;
+
+public:
+    /// @brief Constructor.
+    /// @param max_memory The maximum amount of memory to be used by the cache, in bytes.
+    explicit ConstraintMemory(size_t max_memory);
+
+    /// @brief Clears the policy.
+    void clear();
+
+    /// @brief Determines whether an insertion candidate can be added into the cache.
+    /// @details That is, whether the constraint would still be satisfied after inserting the candidate.
+    /// @param key The key of the insertion candidate.
+    /// @param item The candidate item.
+    /// @return Whether the item can be added in cache.
+    [[nodiscard]] bool can_add(const Key& key, const CacheItem& item);
+
+    /// @brief Determines whether an item already in cache can be updated.
+    /// @details That is, whether the key can be updated to the new value while still satisfying the constraint.
+    /// @param key The key to be updated.
+    /// @param old_item The current value of the key in cache.
+    /// @param new_item The value that would replace the current value.
+    /// @return Whether the item can be replaced.
+    [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+
+    /// @brief Returns whether a key being looked up in cache still satisfies the constraint.
+    /// @details For this constraint, can_find always returns true because an item cannot become invalidated.
+    /// @param key The key of the insertion candidate.
+    /// @return Whether the key is still valid.
+    [[nodiscard]] bool is_invalidated(const Key& key);
+
+    /// @brief Returns whether the constraint is satisfied.
+    /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
+    /// @return Whether the cache constraint is satisfied.
+    [[nodiscard]] bool is_satisfied();
+
+    /// @brief Update the cache constraint.
+    /// @details Sets a new maximum amount of memory.
+    /// @param max_memory The new maximum amount of memory to be used by the cache.
+    void update(size_t max_memory);
+
+    /// @brief Get the amount of memory currently used by the cache.
+    /// @return The current amount of memory used, in bytes.
+    [[nodiscard]] size_t memory() const;
+
+    /// @brief Get the maximum amount of memory that can be used by the cache.
+    /// @return The maximum amount of memory, in bytes.
+    [[nodiscard]] size_t maximum_memory() const;
+
+    /// @brief Insertion event handler.
+    /// @details Adds the size of this item to the amount of memory used.
+    /// @param key The key of the inserted item.
+    /// @param item The item that has been inserted in cache.
+    void on_insert(const Key& key, const CacheItem& item);
+
+    /// @brief Update event handler.
+    /// @details Updates the amount of memory used to reflect the size difference between the old and the new value.
+    /// @param key The key that has been updated in the cache.
+    /// @param old_item The old value for this key.
+    /// @param new_item The new value for this key
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+
+    /// @brief Eviction event handler.
+    /// @details Removes the item at the back of the list - ensuring it has the provided key.
+    /// @param key The key that was evicted.
+    /// @param item The item that was evicted.
+    void on_evict(const Key& key, const CacheItem& item);
+
+private:
+    size_t m_maximum_memory;
+    size_t m_memory = 0;
+};
+
+}  // namespace cachemere::policy
+
+#include "constraint_memory.hpp"
+
+#endif

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -36,12 +36,6 @@ public:
     /// @return Whether the item can be replaced.
     [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
-    /// @brief Returns whether a key being looked up in cache still satisfies the constraint.
-    /// @details For this constraint, can_find always returns true because an item cannot become invalidated.
-    /// @param key The key of the insertion candidate.
-    /// @return Whether the key is still valid.
-    [[nodiscard]] bool is_invalidated(const Key& key);
-
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
     /// @return Whether the cache constraint is satisfied.

--- a/include/cachemere/policy/constraint_memory.hpp
+++ b/include/cachemere/policy/constraint_memory.hpp
@@ -21,11 +21,6 @@ template<typename K, typename V> bool ConstraintMemory<K, V>::can_replace(const 
     return ((m_memory - old_item.m_value_size) + new_item.m_value_size) <= m_maximum_memory;
 }
 
-template<typename K, typename V> bool ConstraintMemory<K, V>::is_invalidated(const K& /*key*/)
-{
-    return false;
-}
-
 template<typename K, typename V> bool ConstraintMemory<K, V>::is_satisfied()
 {
     return m_memory <= m_maximum_memory;

--- a/include/cachemere/policy/constraint_memory.hpp
+++ b/include/cachemere/policy/constraint_memory.hpp
@@ -1,0 +1,68 @@
+namespace cachemere::policy {
+
+template<typename K, typename V> ConstraintMemory<K, V>::ConstraintMemory(size_t max_memory)
+{
+    update(max_memory);
+}
+
+template<typename K, typename V> void ConstraintMemory<K, V>::clear()
+{
+    m_memory = 0;
+}
+
+template<typename K, typename V> bool ConstraintMemory<K, V>::can_add(const K& /* key */, const CacheItem& item)
+{
+    return (m_memory + item.m_total_size) <= m_maximum_memory;
+}
+
+template<typename K, typename V> bool ConstraintMemory<K, V>::can_replace(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+{
+    assert(old_item.m_key_size == new_item.m_key_size);  // Key size *really* shouldn't have changed since the key is supposed to be const.
+    return ((m_memory - old_item.m_value_size) + new_item.m_value_size) <= m_maximum_memory;
+}
+
+template<typename K, typename V> bool ConstraintMemory<K, V>::is_invalidated(const K& /*key*/)
+{
+    return false;
+}
+
+template<typename K, typename V> bool ConstraintMemory<K, V>::is_satisfied()
+{
+    return m_memory <= m_maximum_memory;
+}
+
+template<typename K, typename V> void ConstraintMemory<K, V>::update(size_t max_memory)
+{
+    m_maximum_memory = max_memory;
+}
+
+template<typename K, typename V> size_t ConstraintMemory<K, V>::memory() const
+{
+    return m_memory;
+}
+
+template<typename K, typename V> size_t ConstraintMemory<K, V>::maximum_memory() const
+{
+    return m_maximum_memory;
+}
+
+template<typename K, typename V> void ConstraintMemory<K, V>::on_insert(const K& /* key */, const CacheItem& item)
+{
+    m_memory += item.m_total_size;
+    assert(m_memory <= m_maximum_memory);
+}
+
+template<typename K, typename V> void ConstraintMemory<K, V>::on_update(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+{
+    m_memory -= old_item.m_value_size;
+    m_memory += new_item.m_value_size;
+    assert(m_memory <= m_maximum_memory);
+}
+
+template<typename K, typename V> void ConstraintMemory<K, V>::on_evict(const K& /* key */, const CacheItem& item)
+{
+    assert(item.m_total_size <= m_memory);
+    m_memory -= item.m_total_size;
+}
+
+}  // namespace cachemere::policy

--- a/include/cachemere/policy/detail/bloom_filter.h
+++ b/include/cachemere/policy/detail/bloom_filter.h
@@ -1,10 +1,21 @@
 #ifndef CACHEMERE_BLOOM_FILTER_H
 #define CACHEMERE_BLOOM_FILTER_H
 
-#include <boost/dynamic_bitset.hpp>
 #include <cstdint>
 #include <functional>
 #include <random>
+
+#ifdef _WIN32
+#    pragma warning(push)
+#    pragma warning(disable : 4244)
+#    pragma warning(disable : 4018)
+#endif
+
+#include <boost/dynamic_bitset.hpp>
+
+#ifdef _WIN32
+#    pragma warning(pop)
+#endif
 
 #include "hash_mixer.h"
 

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -36,7 +36,7 @@ private:
     using PrioritySetIt = typename PrioritySet::const_iterator;
 
 public:
-    using CacheItem = cachemere::Item<Value>;
+    using CacheItem = Item<Value>;
 
     /// @brief Iterator for iterating over cache items in the order they should be
     ///        evicted.
@@ -75,8 +75,9 @@ public:
     /// @brief Update event handler.
     /// @details Updates the coefficient for this item and changes its position in the priority queue.
     /// @param key The key that has been updated in the cache.
-    /// @param item The item that has been updated in the cache.
-    void on_update(const Key& key, const CacheItem& item);
+    /// @param old_item The old value for this key.
+    /// @param new_item The new value for this key.
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Cache hit event handler.
     /// @details Updates the coefficient for this item and changes its position in the priority queue.
@@ -86,8 +87,9 @@ public:
 
     /// @brief Eviction event handler.
     /// @details Removes the item from the priority queue.
-    /// @param item The key of the item that was evicted.
-    void on_evict(const Key& key);
+    /// @param key The key that was evicted.
+    /// @param item The item that was evicted.
+    void on_evict(const Key& key, const CacheItem& item);
 
     /// @brief Get an iterator to the first item that should be evicted.
     /// @return An item iterator.

--- a/include/cachemere/policy/eviction_gdsf.hpp
+++ b/include/cachemere/policy/eviction_gdsf.hpp
@@ -62,9 +62,10 @@ template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>
     m_iterator_map[std::ref(key)] = std::move(it);
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_update(const Key& key, const CacheItem& item)
+template<class Key, class Value, class Cost>
+void EvictionGDSF<Key, Value, Cost>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
 {
-    on_cache_hit(key, item);
+    on_cache_hit(key, new_item);
 }
 
 template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_cache_hit(const Key& key, const CacheItem& item)
@@ -79,7 +80,7 @@ template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>
     on_insert(key, item);
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_evict(const Key& key)
+template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_evict(const Key& key, const CacheItem& /* item */)
 {
     auto keyref_and_it = m_iterator_map.find(std::ref(key));
     assert(keyref_and_it != m_iterator_map.end());

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -57,8 +57,9 @@ public:
     /// @brief Update event handler.
     /// @details Moves the provided item to the front of the list.
     /// @param key The key that has been updated in the cache.
-    /// @param item The item that has been updated in the cache.
-    void on_update(const Key& key, const CacheItem& item);
+    /// @param old_item The old value for this key.
+    /// @param new_item The new value for this key
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Cache hit event handler.
     /// @details Moves the provided item at the front of the list.
@@ -68,8 +69,9 @@ public:
 
     /// @brief Eviction event handler.
     /// @details Removes the item at the back of the list - ensuring it has the provided key.
-    /// @param item The key of the item that was evicted.
-    void on_evict(const Key& item);
+    /// @param key The key that was evicted.
+    /// @param item The item that was evicted.
+    void on_evict(const Key& key, const CacheItem& item);
 
     /// @brief Get an iterator to the first item that should be evicted.
     /// @details Considering that the keys are ordered internally from most-recently used

--- a/include/cachemere/policy/eviction_lru.hpp
+++ b/include/cachemere/policy/eviction_lru.hpp
@@ -44,9 +44,9 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_insert(const K
     m_nodes.emplace(std::ref(key), m_keys.begin());
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_update(const Key& key, const CacheItem& item)
+template<class Key, class Value> void EvictionLRU<Key, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
 {
-    on_cache_hit(key, item);
+    on_cache_hit(key, new_item);
 }
 
 template<class Key, class Value> void EvictionLRU<Key, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
@@ -63,7 +63,7 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_cache_hit(cons
     }
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_evict(const Key& key)
+template<class Key, class Value> void EvictionLRU<Key, Value>::on_evict(const Key& key, const CacheItem& /* item */)
 {
     assert(!m_nodes.empty());
     assert(!m_keys.empty());

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -64,8 +64,9 @@ public:
     ///          segment. If the item is in the protected segment, it is moved to the front of
     ///          the protected segment.
     /// @param key The key that has been updated in the cache.
-    /// @param item The item that has been updated in the cache.
-    void on_update(const Key& key, const CacheItem& item);
+    /// @param old_item The old value for this key.
+    /// @param new_item The new value for this key
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Cache hit event handler.
     /// @details If the item is in the probation segment, it is moved to the protected
@@ -77,8 +78,9 @@ public:
 
     /// @brief Eviction event handler.
     /// @details Removes the item from the segment it belongs to.
-    /// @param item The key of the item that was evicted.
-    void on_evict(const Key& item);
+    /// @param key The key that was evicted.
+    /// @param item The item that was evicted.
+    void on_evict(const Key& key, const CacheItem& item);
 
     /// @brief Get an iterator to the first item that should be evicted.
     /// @details Considering that the keys are ordered internally from most-recently used

--- a/include/cachemere/policy/eviction_segmented_lru.hpp
+++ b/include/cachemere/policy/eviction_segmented_lru.hpp
@@ -68,9 +68,9 @@ template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_inser
     m_probation_nodes.emplace(std::ref(key), m_probation_list.begin());
 }
 
-template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_update(const Key& key, const CacheItem& item)
+template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
 {
-    on_cache_hit(key, item);
+    on_cache_hit(key, new_item);
 }
 
 template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
@@ -100,7 +100,7 @@ template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_cache
     assert(m_protected_nodes.size() == m_protected_list.size());
 }
 
-template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_evict(const Key& key)
+template<class Key, class Value> void EvictionSegmentedLRU<Key, Value>::on_evict(const Key& key, const CacheItem& /* item */)
 {
     assert((!m_protected_list.empty()) || !m_probation_list.empty());
 

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -52,6 +52,7 @@ public:
     ///          estimation for both keys. It will return `true` only if it estimates
     ///          that the candidate key is accessed more frequently than the victim key.
     /// @param victim The key of the victim the candidate will be compared to.
+    /// @param candidate The replacement candidate.
     bool should_replace(const Key& victim, const Key& candidate);
 
 private:

--- a/include/cachemere/presets.h
+++ b/include/cachemere/presets.h
@@ -4,6 +4,9 @@
 #include "cache.h"
 #include "measurement.h"
 
+#include "policy/bind.h"
+#include "policy/constraint_count.h"
+#include "policy/constraint_memory.h"
 #include "policy/eviction_lru.h"
 #include "policy/eviction_segmented_lru.h"
 #include "policy/eviction_gdsf.h"
@@ -13,14 +16,29 @@
 /// @brief Frequently-used cache presets.
 namespace cachemere::presets {
 
+/// @brief Memory-constrained cache presets.
+namespace memory {
+
+template<typename Key,
+         typename Value,
+         template<class, class>
+         class InsertionPolicy,
+         template<class, class>
+         class EvictionPolicy,
+         typename MeasureValue = measurement::Size<Value>,
+         typename MeasureKey   = measurement::Size<Key>,
+         bool ThreadSafe       = true>
+using MemoryConstrainedCache = Cache<Key, Value, InsertionPolicy, EvictionPolicy, policy::ConstraintMemory, MeasureValue, MeasureKey, ThreadSafe>;
+
 /// @brief Least-Recently-Used Cache.
 /// @details Uses a linked list to order items from hottest (most recently accessed) to coldest (least recently accessed).
 /// @tparam Key The type of the key used for retrieving items.
 /// @tparam Value The type of the items stored in the cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
 template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
-using LRUCache = Cache<Key, Value, policy::InsertionAlways, policy::EvictionLRU, MeasureValue, MeasureKey, ThreadSafe>;
+using LRUCache = MemoryConstrainedCache<Key, Value, policy::InsertionAlways, policy::EvictionLRU, MeasureValue, MeasureKey, ThreadSafe>;
 
 /// @brief TinyLFU Cache.
 /// @details Uses a combination of frequency sketches to gather a decent estimate of the access frequency of most keys.
@@ -29,23 +47,9 @@ using LRUCache = Cache<Key, Value, policy::InsertionAlways, policy::EvictionLRU,
 /// @tparam Value The type of the items stored in the cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
 template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
-using TinyLFUCache = Cache<Key, Value, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU, MeasureValue, MeasureKey, ThreadSafe>;
-
-namespace detail {
-
-// Template helper to allow partial specialization of Cost.
-template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
-class SpecializedGDSFCache
-{
-private:
-    template<typename K, typename V> using MyGDSF = policy::EvictionGDSF<K, V, Cost>;
-
-public:
-    using type = Cache<Key, Value, policy::InsertionAlways, MyGDSF, MeasureValue, MeasureKey, ThreadSafe>;
-};
-
-}  // namespace detail
+using TinyLFUCache = MemoryConstrainedCache<Key, Value, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU, MeasureValue, MeasureKey, ThreadSafe>;
 
 /// @brief Custom-Cost Cache.
 /// @details The use of this cache should be favored in scenarios where the cost of a cache miss varies greatly from one item to the next.
@@ -54,8 +58,70 @@ public:
 /// @tparam Cost A functor taking a `const Item<Key, Value>&` returning the cost to load this item in cache.
 /// @tparam MeasureValue A functor returning the size of a cache value.
 /// @tparam MeasureKey A functor returning the size of a cache key.
-template<typename Key, typename Value, typename Cost, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
-using CustomCostCache = typename detail::SpecializedGDSFCache<Key, Value, Cost, MeasureValue, MeasureKey, ThreadSafe>::type;
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
+template<typename Key,
+         typename Value,
+         typename Cost,
+         typename MeasureValue = measurement::Size<Value>,
+         typename MeasureKey   = measurement::Size<Key>,
+         bool ThreadSafe       = true>
+using CustomCostCache =
+    MemoryConstrainedCache<Key, Value, policy::InsertionAlways, policy::bind<policy::EvictionGDSF, Cost>::template ttype, MeasureValue, MeasureKey, ThreadSafe>;
+
+}  // namespace memory
+
+/// @brief Count-constrained cache presets.
+namespace count {
+
+template<typename Key,
+         typename Value,
+         template<class, class>
+         class InsertionPolicy,
+         template<class, class>
+         class EvictionPolicy,
+         typename MeasureValue = measurement::Size<Value>,
+         typename MeasureKey   = measurement::Size<Key>,
+         bool ThreadSafe       = true>
+using CountConstrainedCache = Cache<Key, Value, InsertionPolicy, EvictionPolicy, policy::ConstraintCount, MeasureValue, MeasureKey, ThreadSafe>;
+
+/// @brief Least-Recently-Used Cache.
+/// @details Uses a linked list to order items from hottest (most recently accessed) to coldest (least recently accessed).
+/// @tparam Key The type of the key used for retrieving items.
+/// @tparam Value The type of the items stored in the cache.
+/// @tparam MeasureValue A functor returning the size of a cache value.
+/// @tparam MeasureKey A functor returning the size of a cache key.
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
+template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
+using LRUCache = CountConstrainedCache<Key, Value, policy::InsertionAlways, policy::EvictionLRU, MeasureValue, MeasureKey, ThreadSafe>;
+
+/// @brief TinyLFU Cache.
+/// @details Uses a combination of frequency sketches to gather a decent estimate of the access frequency of most keys.
+///          Uses this estimate to decide which item should be held in cache over another.
+/// @tparam Key The type of the key used for retrieving items.
+/// @tparam Value The type of the items stored in the cache.
+/// @tparam MeasureValue A functor returning the size of a cache value.
+/// @tparam MeasureKey A functor returning the size of a cache key.
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
+template<typename Key, typename Value, typename MeasureValue = measurement::Size<Value>, typename MeasureKey = measurement::Size<Key>, bool ThreadSafe = true>
+using TinyLFUCache = CountConstrainedCache<Key, Value, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU, MeasureValue, MeasureKey, ThreadSafe>;
+
+/// @brief Custom-Cost Cache.
+/// @details The use of this cache should be favored in scenarios where the cost of a cache miss varies greatly from one item to the next.
+/// @tparam Key The type of the key used for retrieving items.
+/// @tparam Value The type of the items stored in the cache.
+/// @tparam Cost A functor taking a `const Item<Key, Value>&` returning the cost to load this item in cache.
+/// @tparam MeasureValue A functor returning the size of a cache value.
+/// @tparam MeasureKey A functor returning the size of a cache key.
+/// @tparam ThreadSafe Whether to protect this cache for concurrent access. (true by default)
+template<typename Key,
+         typename Value,
+         typename Cost,
+         typename MeasureValue = measurement::Size<Value>,
+         typename MeasureKey   = measurement::Size<Key>,
+         bool ThreadSafe       = true>
+using CustomCostCache =
+    CountConstrainedCache<Key, Value, policy::InsertionAlways, policy::bind<policy::EvictionGDSF, Cost>::template ttype, MeasureValue, MeasureKey, ThreadSafe>;
+}  // namespace count
 
 }  // namespace cachemere::presets
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,8 +12,12 @@ target_link_libraries(cachemere_tests
 
 target_sources(cachemere_tests
     PRIVATE
+        src/count_cache_tests.cpp
+        src/memory_cache_tests.cpp
         src/cache_tests.cpp
         src/measurement_tests.cpp
+        src/policy/constraint_count_tests.cpp
+        src/policy/constraint_memory_tests.cpp
         src/policy/eviction_lru_tests.cpp
         src/policy/eviction_gdsf_tests.cpp
         src/policy/eviction_segmented_lru_tests.cpp

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <list>
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <random>
@@ -25,9 +26,6 @@ struct Point3D {
 
 using namespace cachemere;
 
-using LRUCache     = presets::LRUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
-using TinyLFUCache = presets::TinyLFUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
-
 struct RandomCost {
     double operator()(const uint32_t& /* key */, const Item<Point3D>& /* item */)
     {
@@ -38,7 +36,13 @@ struct RandomCost {
     }
 };
 
-using CustomCostCache = presets::CustomCostCache<uint32_t, Point3D, RandomCost, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using MemoryLRUCache        = presets::memory::LRUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using MemoryTinyLFUCache    = presets::memory::TinyLFUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using MemoryCustomCostCache = presets::memory::CustomCostCache<uint32_t, Point3D, RandomCost, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+
+using CountLRUCache        = presets::count::LRUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using CountTinyLFUCache    = presets::count::TinyLFUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using CountCustomCostCache = presets::count::CustomCostCache<uint32_t, Point3D, RandomCost, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
 
 template<typename CacheT> class CacheTest : public testing::Test
 {
@@ -50,11 +54,11 @@ public:
 
     std::shared_ptr<CacheT> new_cache(std::vector<std::pair<uint32_t, Point3D>> collection, size_t size)
     {
-        return std::make_shared<CacheT>(collection, size);
+        return std::make_shared<CacheT>(collection, std::make_tuple(size));
     }
 };
 
-using TestTypes = testing::Types<LRUCache, TinyLFUCache, CustomCostCache>;
+using TestTypes = testing::Types<MemoryLRUCache, MemoryTinyLFUCache, MemoryCustomCostCache, CountLRUCache, CountTinyLFUCache, CountCustomCostCache>;
 
 class NonCopyString : public std::string
 {
@@ -73,6 +77,15 @@ public:
     NonCopyString(const NonCopyString&) = delete;
     NonCopyString& operator=(const NonCopyString&) = delete;
 };
+
+namespace std {
+template<> struct hash<NonCopyString> {
+    size_t operator()(const NonCopyString& s) const noexcept
+    {
+        return std::hash<std::string>{}(static_cast<const std::string&>(s));
+    }
+};
+}  // namespace std
 
 TYPED_TEST_SUITE(CacheTest, TestTypes);
 
@@ -156,24 +169,6 @@ TYPED_TEST(CacheTest, MultiThreadLong)
 
     std::cout << "Total of " << op_count << " operations in 10.0s";
     std::cout << "Hit rate: " << cache->hit_rate() << std::endl;
-}
-
-TYPED_TEST(CacheTest, Resize)
-{
-    auto cache = TestFixture::new_cache(10 * sizeof(Point3D));
-
-    // Insert all items and make sure they all fit in cache.
-    const uint32_t number_of_items = 5;
-    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
-        cache->find(point_id);  // Trigger a cache miss so TinyLFU has seen the item once.
-        cache->insert(point_id, Point3D{point_id, point_id, point_id});
-    }
-    EXPECT_EQ(cache->number_of_items(), number_of_items);
-
-    // Resize the cache, make sure some were evicted.
-    cache->set_maximum_size(4 * sizeof(Point3D));
-    EXPECT_LE(cache->size(), 4 * sizeof(Point3D));
-    EXPECT_EQ(cache->number_of_items(), 2);  // Only two items fit because of the cache overhead.
 }
 
 TYPED_TEST(CacheTest, RemoveWhenKeyPresent)
@@ -297,20 +292,10 @@ TYPED_TEST(CacheTest, Clear)
     EXPECT_FALSE(cache->contains(2));
 }
 
-TYPED_TEST(CacheTest, ImportConstructionNotEnoughSpace)
-{
-    auto cache = TestFixture::new_cache({{1, Point3D{1, 1, 1}}, {2, Point3D{2, 2, 2}}, {3, Point3D{3, 3, 3}}},
-                                        4 * sizeof(Point3D));  // Only 2 items fit because of overhead.
-
-    EXPECT_TRUE(cache->contains(1));
-    EXPECT_TRUE(cache->contains(2));
-    EXPECT_FALSE(cache->contains(3));
-}
-
 TEST(CacheTest, NoValueCopyOnInsert)
 {
     using PtrCache =
-        presets::LRUCache<std::string, std::unique_ptr<Point3D>, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
+        presets::memory::LRUCache<std::string, std::unique_ptr<Point3D>, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
 
     PtrCache cache{10 * sizeof(Point3D)};
 
@@ -321,13 +306,13 @@ TEST(CacheTest, NoValueCopyOnInsert)
 TEST(CacheTest, NoValueCopyOnImportConstruction)
 {
     using PtrCache =
-        presets::LRUCache<std::string, std::unique_ptr<Point3D>, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
+        presets::memory::LRUCache<std::string, std::unique_ptr<Point3D>, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
 
     std::vector<std::pair<std::string, std::unique_ptr<Point3D>>> items;
     items.emplace_back("a", std::make_unique<Point3D>(1, 1, 1));
     items.emplace_back("b", std::make_unique<Point3D>(2, 2, 2));
 
-    PtrCache cache{items, 10 * sizeof(Point3D)};
+    PtrCache cache{items, std::make_tuple(10 * sizeof(Point3D))};
 
     EXPECT_TRUE(cache.contains("a"));
 }
@@ -336,7 +321,7 @@ TEST(CacheTest, NoKeyCopyOnInsert)
 {
     NonCopyString test_key("asdf");
 
-    using TestCache = presets::LRUCache<NonCopyString, Point3D, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
+    using TestCache = presets::memory::LRUCache<NonCopyString, Point3D, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
 
     TestCache cache{10 * sizeof(Point3D)};
 
@@ -345,14 +330,14 @@ TEST(CacheTest, NoKeyCopyOnInsert)
 
 TEST(CacheTest, NoKeyCopyOnImportConstruction)
 {
-    using TestCache = presets::LRUCache<NonCopyString, Point3D, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
+    using TestCache = presets::memory::LRUCache<NonCopyString, Point3D, measurement::SizeOf<Point3D>, measurement::CapacityDynamicallyAllocated<std::string>>;
 
     std::vector<std::pair<NonCopyString, Point3D>> items;
     items.emplace_back(NonCopyString("a"), Point3D(1, 1, 1));
     items.emplace_back(NonCopyString("b"), Point3D(1, 1, 1));
     items.emplace_back(NonCopyString("c"), Point3D(1, 1, 1));
 
-    TestCache cache{items, 10 * sizeof(Point3D)};
+    TestCache cache{items, std::make_tuple(10 * sizeof(Point3D))};
 
     EXPECT_TRUE(cache.contains(NonCopyString("a")));
 }

--- a/tests/src/count_cache_tests.cpp
+++ b/tests/src/count_cache_tests.cpp
@@ -1,0 +1,66 @@
+/// Tests that are specific to the count-constrained cache.
+#include <gtest/gtest.h>
+
+#include "cachemere/cache.h"
+#include "cachemere/measurement.h"
+#include "cachemere/presets.h"
+
+using namespace cachemere;
+
+struct Point3D {
+    Point3D(uint32_t a, uint32_t b, uint32_t c) : x(a), y(b), z(c)
+    {
+    }
+
+    uint32_t x;
+    uint32_t y;
+    uint32_t z;
+};
+
+struct RandomCost {
+    double operator()(const uint32_t& /* key */, const Item<Point3D>& /* item */)
+    {
+        const int min = 0;
+        const int max = 100;
+
+        return static_cast<double>(min + (rand() % static_cast<int>(max - min + 1)));
+    }
+};
+
+using CountLRUCache        = presets::count::LRUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using CountTinyLFUCache    = presets::count::TinyLFUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using CountCustomCostCache = presets::count::CustomCostCache<uint32_t, Point3D, RandomCost, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+
+using TestTypes = testing::Types<CountLRUCache, CountTinyLFUCache, CountCustomCostCache>;
+
+template<typename CacheT> class CountCacheTest : public testing::Test
+{
+public:
+    std::shared_ptr<CacheT> new_cache(size_t size)
+    {
+        return std::make_shared<CacheT>(size);
+    }
+
+    std::shared_ptr<CacheT> new_cache(std::vector<std::pair<uint32_t, Point3D>> collection, size_t size)
+    {
+        return std::make_shared<CacheT>(collection, std::make_tuple(size));
+    }
+};
+
+TYPED_TEST_SUITE(CountCacheTest, TestTypes);
+
+TYPED_TEST(CountCacheTest, Resize)
+{
+    const size_t original_item_count = 10;
+
+    auto cache = TestFixture::new_cache(original_item_count);
+
+    for (uint32_t point_id = 0; point_id < original_item_count; ++point_id) {
+        cache->find(point_id);  // Trigger a cache miss so TinyLFU has seen the item once.
+        cache->insert(point_id, Point3D{point_id, point_id, point_id});
+    }
+
+    EXPECT_EQ(cache->number_of_items(), original_item_count);
+    cache->update_constraint(3);
+    EXPECT_EQ(cache->number_of_items(), 3);
+}

--- a/tests/src/memory_cache_tests.cpp
+++ b/tests/src/memory_cache_tests.cpp
@@ -1,0 +1,80 @@
+/// Tests that are specific to the memory-constrained cache.
+#include <gtest/gtest.h>
+
+#include "cachemere/cache.h"
+#include "cachemere/measurement.h"
+#include "cachemere/presets.h"
+
+using namespace cachemere;
+
+struct Point3D {
+    Point3D(uint32_t a, uint32_t b, uint32_t c) : x(a), y(b), z(c)
+    {
+    }
+
+    uint32_t x;
+    uint32_t y;
+    uint32_t z;
+};
+
+using MemoryLRUCache     = presets::memory::LRUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+using MemoryTinyLFUCache = presets::memory::TinyLFUCache<uint32_t, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+
+struct RandomCost {
+    double operator()(const uint32_t& /* key */, const Item<Point3D>& /* item */)
+    {
+        const int min = 0;
+        const int max = 100;
+
+        return static_cast<double>(min + (rand() % static_cast<int>(max - min + 1)));
+    }
+};
+
+using MemoryCustomCostCache = presets::memory::CustomCostCache<uint32_t, Point3D, RandomCost, measurement::SizeOf<Point3D>, measurement::SizeOf<uint32_t>>;
+
+using TestTypes = testing::Types<MemoryLRUCache, MemoryTinyLFUCache, MemoryCustomCostCache>;
+
+template<typename CacheT> class MemoryCacheTest : public testing::Test
+{
+public:
+    std::shared_ptr<CacheT> new_cache(size_t size)
+    {
+        return std::make_shared<CacheT>(size);
+    }
+
+    std::shared_ptr<CacheT> new_cache(std::vector<std::pair<uint32_t, Point3D>> collection, size_t size)
+    {
+        return std::make_shared<CacheT>(collection, std::make_tuple(size));
+    }
+};
+
+TYPED_TEST_SUITE(MemoryCacheTest, TestTypes);
+
+TYPED_TEST(MemoryCacheTest, Resize)
+{
+    const size_t original_size = 10 * (sizeof(Point3D) + sizeof(uint32_t));
+    auto         cache         = TestFixture::new_cache(original_size);
+
+    // Insert all items and make sure they all fit in cache.
+    const uint32_t number_of_items = 5;
+    for (uint32_t point_id = 0; point_id < number_of_items; ++point_id) {
+        cache->find(point_id);  // Trigger a cache miss so TinyLFU has seen the item once.
+        cache->insert(point_id, Point3D{point_id, point_id, point_id});
+    }
+    EXPECT_EQ(cache->number_of_items(), number_of_items);
+
+    // Resize the cache, make sure some were evicted.
+    size_t new_cache_size = 2 * (sizeof(Point3D) + sizeof(uint32_t));
+    cache->update_constraint(new_cache_size);
+    EXPECT_LE(cache->constraint_policy().memory(), new_cache_size);
+    EXPECT_EQ(cache->number_of_items(), 2);
+}
+
+TYPED_TEST(MemoryCacheTest, ImportConstructionNotEnoughSpace)
+{
+    auto cache = TestFixture::new_cache({{1, Point3D{1, 1, 1}}, {2, Point3D{2, 2, 2}}, {3, Point3D{3, 3, 3}}}, 2 * (sizeof(uint32_t) + sizeof(Point3D)));
+
+    EXPECT_TRUE(cache->contains(1));
+    EXPECT_TRUE(cache->contains(2));
+    EXPECT_FALSE(cache->contains(3));
+}

--- a/tests/src/policy/constraint_count_tests.cpp
+++ b/tests/src/policy/constraint_count_tests.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include "cachemere/item.h"
+#include "cachemere/policy/constraint_count.h"
+
+using namespace cachemere;
+
+using TestItem       = Item<uint32_t>;
+using TestConstraint = policy::ConstraintCount<std::string, uint32_t>;
+
+TEST(ConstraintCount, InitializesMaxCountAndCount)
+{
+    TestConstraint constraint{10};
+
+    EXPECT_EQ(constraint.count(), 0);
+    EXPECT_EQ(constraint.maximum_count(), 10);
+}
+
+TEST(ConstraintCount, CanAddWhenEnoughRoom)
+{
+    TestConstraint constraint{2};
+    EXPECT_TRUE(constraint.can_add("asdf", TestItem{1, 1, 1}));
+}
+
+TEST(ConstraintCount, CanAddWhenFull)
+{
+    TestConstraint constraint{2};
+
+    for (uint32_t i = 0; i < 2; ++i) {
+        constraint.on_insert("asdf", TestItem{i, i, i});
+    }
+
+    EXPECT_EQ(constraint.count(), 2);
+    EXPECT_FALSE(constraint.can_add("asdf", TestItem{1, 1, 1}));
+}
+
+TEST(ConstraintCount, CanReplaceWhenThereIsRoom)
+{
+    TestConstraint constraint{2};
+    constraint.on_insert("asdf", TestItem{1, 1, 1});
+
+    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2}));
+}
+
+TEST(ConstraintCount, CanReplaceWhenFull)
+{
+    TestConstraint constraint{1};
+    constraint.on_insert("asdf", TestItem{1, 1, 1});
+
+    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2}));
+}
+
+TEST(ConstraintCount, OnEvictDecreasesCount)
+{
+    TestConstraint constraint{1};
+    constraint.on_insert("asdf", TestItem{1, 1, 1});
+    EXPECT_EQ(constraint.count(), 1);
+
+    constraint.on_evict("asdf", TestItem{1, 1, 1});
+    EXPECT_EQ(constraint.count(), 0);
+}
+
+TEST(ConstraintCount, IsSatisfiedDetectsOverflows)
+{
+    TestConstraint constraint{10};
+    EXPECT_TRUE(constraint.is_satisfied());
+
+    for (uint32_t i = 0; i < 10; ++i) {
+        constraint.on_insert("asdf", TestItem{i, i, i});
+    }
+
+    EXPECT_TRUE(constraint.is_satisfied());
+
+    constraint.update(5);
+    EXPECT_FALSE(constraint.is_satisfied());
+}

--- a/tests/src/policy/constraint_memory_tests.cpp
+++ b/tests/src/policy/constraint_memory_tests.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include "cachemere/item.h"
+#include "cachemere/policy/constraint_memory.h"
+
+using namespace cachemere;
+
+using TestItem       = Item<uint32_t>;
+using TestConstraint = policy::ConstraintMemory<std::string, uint32_t>;
+
+TEST(ConstraintMemory, InitializesMaxMemoryAndMemory)
+{
+    TestConstraint constraint{10};  // Max 10 bytes.
+
+    EXPECT_EQ(constraint.memory(), 0);
+    EXPECT_EQ(constraint.maximum_memory(), 10);
+}
+
+TEST(ConstraintMemory, CanAddWhenEnoughRoom)
+{
+    TestConstraint constraint{10};
+
+    EXPECT_TRUE(constraint.can_add("asdf", TestItem{4, 42, 4}));
+}
+
+TEST(ConstraintMemory, CanAddWhenFull)
+{
+    TestConstraint constraint{10};
+
+    constraint.on_insert("asdf", TestItem{5, 42, 5});
+    EXPECT_FALSE(constraint.can_add("hjkl", TestItem{1, 42, 1}));
+}
+
+TEST(ConstraintMemory, CanAddWhenItemTooBig)
+{
+    TestConstraint constraint{10};
+
+    EXPECT_FALSE(constraint.can_add("asdf", TestItem{5, 42, 6}));
+}
+
+TEST(ConstraintMemory, CanReplaceWhenEnoughRoom)
+{
+    TestConstraint constraint{10};
+    constraint.on_insert("asdf", TestItem{1, 42, 1});
+
+    EXPECT_EQ(constraint.memory(), 2);
+
+    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 9}));
+
+    constraint.on_update("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 9});
+
+    EXPECT_EQ(constraint.memory(), 10);
+}
+
+TEST(ConstraintMemory, CanReplaceWhenItemGrewTooMuch)
+{
+    TestConstraint constraint{10};
+    constraint.on_insert("asdf", TestItem{1, 42, 1});
+
+    EXPECT_FALSE(constraint.can_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 10}));
+}
+
+TEST(ConstraintMemory, CanReplaceWhenShrunk)
+{
+    TestConstraint constraint{10};
+    constraint.on_insert("asdf", TestItem{1, 42, 9});
+
+    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 42, 9}, TestItem{1, 42, 8}));
+}
+
+TEST(ConstraintMemory, OnEvictFreesMemory)
+{
+    TestConstraint constraint{10};
+    constraint.on_insert("asdf", TestItem{1, 42, 9});
+    EXPECT_EQ(constraint.memory(), 10);
+    constraint.on_evict("asdf", TestItem{1, 42, 9});
+    EXPECT_EQ(constraint.memory(), 0);
+}
+
+TEST(ConstraintMemory, IsSatisfiedDetectsOverflows)
+{
+    TestConstraint constraint{10};
+    EXPECT_TRUE(constraint.is_satisfied());
+
+    constraint.on_insert("asdf", TestItem{1, 42, 9});
+    EXPECT_TRUE(constraint.is_satisfied());
+
+    constraint.update(5);
+    EXPECT_FALSE(constraint.is_satisfied());
+}

--- a/tests/src/policy/eviction_gdsf_tests.cpp
+++ b/tests/src/policy/eviction_gdsf_tests.cpp
@@ -55,7 +55,7 @@ TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
 
     for (size_t i = 0; i < 10; ++i) {
         auto key_and_item = item_store.find(long_key);
-        policy.on_update(key_and_item->first, key_and_item->second);
+        policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
 
     // GDSF does take frequency into account, so touching "this is supposed to be a much longer string" a few times gives it priority again.
@@ -64,7 +64,7 @@ TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
     // But since cost/byte is favored, we can load "a" fewer times and get it to stay in cache
     for (size_t i = 0; i < 4; ++i) {
         auto key_and_item = item_store.find(short_key);
-        policy.on_update(key_and_item->first, key_and_item->second);
+        policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
 
     EXPECT_EQ(*policy.victim_begin(), long_key);
@@ -91,12 +91,12 @@ TEST(EvictionGDSF, MaximizeCostPerByteWithQuadraticCost)
     // We can demonstrate this by accessing the short key more than the long key. The bigger item will still be favored.
     for (size_t i = 0; i < 10; ++i) {
         auto key_and_item = item_store.find(short_key);
-        policy.on_update(key_and_item->first, key_and_item->second);
+        policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
 
     for (size_t i = 0; i < 4; ++i) {
         auto key_and_item = item_store.find(long_key);
-        policy.on_update(key_and_item->first, key_and_item->second);
+        policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
     EXPECT_EQ(*policy.victim_begin(), short_key);
 }

--- a/tests/src/policy/eviction_segmented_lru_tests.cpp
+++ b/tests/src/policy/eviction_segmented_lru_tests.cpp
@@ -87,10 +87,10 @@ TEST(EvictionSegmentedLRU, RandomEvictions)
     expect_victims(policy, {"a", "e", "b", "c", "d"});
 
     // Remove something not at the head of the probation segment.
-    policy.on_evict("e");
+    policy.on_evict("e", Item{0, 4, sizeof(uint32_t)});
     expect_victims(policy, {"a", "b", "c", "d"});
 
     // Remove something in the protected segment
-    policy.on_evict("c");
+    policy.on_evict("c", Item{0, 2, sizeof(uint32_t)});
     expect_victims(policy, {"a", "b", "d"});
 }


### PR DESCRIPTION
This adds a third policy to the Cache class. 

Before we had two policies, the insertion & eviction policies.
Repsectively, these policies answered the questions relating to
* Whether we _want_ to have or keep an item in the cache
* If we _can't_ put an item in the cache (due to lack of space or something else), which items should be removed first

This design works fine but doesn't allow the end user to override the algorithm to determine whether an item _can_ be in cache. (With the current behavior, the cache is created with a maximum memory threshold, and exceeding that threshold triggers evictions), so a user wanting a count-limited cache or a TTL cache would need to rewrite the whole cache class.

This PR adds the Constraint Policy, which contains in its interface all hooks required for the cache to figure out whether a given key/value pair _can_ be in the cache, independent of preference.