### PR TITLE
Fix underflow bug when growing cache entries

### DIFF
--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -348,7 +348,7 @@ void Cache<K, V, I, E, SV, SK, TS>::insert_or_update(K&& key, V&& value, size_t 
     auto key_and_item = m_data.find(key);
     if (key_and_item != m_data.end()) {
         // Update.
-        m_current_size = m_current_size + key_and_item->second.m_value_size - value_size;
+        m_current_size = (m_current_size - key_and_item->second.m_value_size) + value_size;
 
         key_and_item->second.m_value      = std::move(value);
         key_and_item->second.m_value_size = value_size;

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -313,3 +313,28 @@ TEST(CacheTest, NoValueCopyOnImportConstruction)
 
     EXPECT_TRUE(cache.contains("a"));
 }
+
+// Reproduces an underflow bug that occurred when growing an object.
+TEST(CacheTest, SizeUpdateNoUnderflow)
+{
+    struct SelfSized {
+        SelfSized(size_t size) : m_size(size)
+        {
+        }
+        size_t size() const
+        {
+            return m_size;
+        }
+
+    private:
+        size_t m_size;
+    };
+
+    using CacheT = presets::LRUCache<uint32_t, SelfSized, measurement::Size<SelfSized>, measurement::SizeOf<uint32_t>>;
+
+    CacheT cache{100};
+
+    cache.insert(1, SelfSized{1});
+    cache.insert(1, SelfSized{11});
+    EXPECT_LT(cache.size(), 100);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "cachemere",
-    "version-semver": "0.1.4",
+    "version-semver": "0.1.5",
     "dependencies": [
         {
             "name": "vcpkg-cmake",


### PR DESCRIPTION
This bug was already fixed by the changes for the [next large version](https://github.com/coveooss/cachemere/pull/20) of cachemere, but we need to fix it here also until it lands!