### PR TITLE
Fix Cache::find not being const after removal of is_invalidated hook

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -85,7 +85,7 @@ public:
     ///          it will be evicted from the cache immediately.
     /// @param key The key to lookup.
     /// @return The value if `key` is in cache, `std::nullopt` otherwise.
-    std::optional<Value> find(const Key& key);
+    std::optional<Value> find(const Key& key) const;
 
     /// @brief Copy the cache contents in the provided container.
     /// @details The container should conform to either of the STL's interfaces for associative

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -81,8 +81,6 @@ public:
     bool contains(const Key& key) const;
 
     /// @brief Find a given key in cache returning the associated value when it exists.
-    /// @details If the key exists in cache but is marked as invalidated by the constraint policy,
-    ///          it will be evicted from the cache immediately.
     /// @param key The key to lookup.
     /// @return The value if `key` is in cache, `std::nullopt` otherwise.
     std::optional<Value> find(const Key& key) const;

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -46,7 +46,7 @@ inline bool Cache<K, V, I, E, C, SV, SK, TS>::contains(const K& key) const
 }
 
 template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key)
+std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key) const
 {
     std::unique_lock<std::recursive_mutex> guard(lock());
 


### PR DESCRIPTION
Since the `is_invalidated` hook (which could cause evictions in `Cache::find`) was removed, `Cache::find` can now safely
be const again.
