### PR TITLE
Use std::lock for swapping

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -62,6 +62,7 @@ public:
     using MyEvictionPolicy   = EvictionPolicy<Key, Value>;
     using MyConstraintPolicy = ConstraintPolicy<Key, Value>;
     using CacheType          = Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, ThreadSafe>;
+    using LockGuard          = std::unique_lock<std::recursive_mutex>;
 
     /// @brief Simple constructor.
     /// @param args Arguments to forward to the constraint policy constructor.
@@ -176,8 +177,11 @@ public:
     void statistics_window_size(uint32_t window_size);
 
 protected:
-    std::unique_lock<std::recursive_mutex> lock() const;
-    template<typename C> void              import(C& collection);
+    LockGuard                       lock() const;
+    LockGuard                       lock(std::defer_lock_t defer_lock_tag) const;
+    std::pair<LockGuard, LockGuard> lock_pair(CacheType& other) const;
+
+    template<typename C> void import(C& collection);
 
 private:
     using CacheItem = Item<Value>;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,46 +1,38 @@
 {
-    "name": "cachemere",
-    "version-semver": "0.2.1",
-    "dependencies": [
-        {
-            "name": "vcpkg-cmake",
-            "version>=": "2021-02-28",
-            "host": true,
-            "$comment": "This transitive dependency needs to be specified explicitly."
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "version>=": "2021-02-26",
-            "host": true,
-            "$comment": "This transitive dependency needs to be specified explicitly."
-        }
-    ],
-    "default-features": [
-        "boost"
-    ],
-    "features": {
-        "boost": {
-            "description": "Use boost from vcpkg",
-            "dependencies": [
-                "boost-accumulators",
-                "boost-dynamic-bitset",
-                "boost-hana"
-            ]
-        },
-        "tests": {
-            "description": "The unit tests",
-            "dependencies": [
-                "gtest"
-            ]
-        },
-        "benchmarks": {
-            "description": "The accuracy and performance benchmarks",
-            "dependencies": [
-                "benchmark",
-                "gtest",
-                "tbb"
-            ]
-        }
+  "name": "cachemere",
+  "version-semver": "0.2.2",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "version>=": "2021-02-28",
+      "host": true,
+      "$comment": "This transitive dependency needs to be specified explicitly."
     },
-    "builtin-baseline": "af5b5d36592242204f2c2a847733bf171ac9c55a"
+    {
+      "name": "vcpkg-cmake-config",
+      "version>=": "2021-02-26",
+      "host": true,
+      "$comment": "This transitive dependency needs to be specified explicitly."
+    }
+  ],
+  "default-features": ["boost"],
+  "features": {
+    "boost": {
+      "description": "Use boost from vcpkg",
+      "dependencies": [
+        "boost-accumulators",
+        "boost-dynamic-bitset",
+        "boost-hana"
+      ]
+    },
+    "tests": {
+      "description": "The unit tests",
+      "dependencies": ["gtest"]
+    },
+    "benchmarks": {
+      "description": "The accuracy and performance benchmarks",
+      "dependencies": ["benchmark", "gtest", "tbb"]
+    }
+  },
+  "builtin-baseline": "af5b5d36592242204f2c2a847733bf171ac9c55a"
 }


### PR DESCRIPTION
This adds support for deadlock-avoidance using `std::lock` while swapping cache instances.