### PR TITLE
Allow custom hashers and switch to abseil structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,11 +88,13 @@ target_sources(cachemere
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/cache.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/cache.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/hash.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/item.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/presets.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/detail/traits.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/detail/transparent_eq.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/bind.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_count.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/constraint_count.hpp>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,26 +7,26 @@ option(USE_VCPKG "Use vcpkg for dependencies" OFF)
 if (USE_VCPKG)
     set(VCPKG_FEATURE_FLAGS "versions")
 
-    if(DEFINED ENV{VCPKG_ROOT})
+    if (DEFINED ENV{VCPKG_ROOT})
         set(CMAKE_TOOLCHAIN_FILE $ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
-            CACHE STRING "Vcpkg toolchain file")
-    else()
+                CACHE STRING "Vcpkg toolchain file")
+    else ()
         set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
-            CACHE STRING "Vcpkg toolchain file")
-    endif()
+                CACHE STRING "Vcpkg toolchain file")
+    endif ()
 
     if (BUILD_TESTS)
         list(APPEND VCPKG_MANIFEST_FEATURES "tests")
-    endif()
+    endif ()
 
     if (BUILD_BENCHMARKS)
         list(APPEND VCPKG_MANIFEST_FEATURES "benchmarks")
-    endif()
-endif()
+    endif ()
+endif ()
 
 if (BUILD_TESTS OR BUILD_BENCHMARKS)
     enable_testing()
-endif()
+endif ()
 
 project(cachemere)
 
@@ -34,50 +34,57 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(Boost 1.65 REQUIRED)
+find_package(absl CONFIG REQUIRED)
 
 add_library(cachemere INTERFACE)
 
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-  add_compile_options("-Wall" "-Wextra")
+    add_compile_options("-Wall" "-Wextra")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options("/W4")
-endif()
+    add_compile_options("/W4")
+endif ()
 
 target_link_libraries(cachemere
-    INTERFACE
+        INTERFACE
         Boost::boost
-)
+
+        absl::container_common
+        absl::btree
+        absl::hash
+        absl::flat_hash_map
+        absl::node_hash_map
+        )
 
 include(GNUInstallDirs)
 target_include_directories(cachemere
-    INTERFACE
+        INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+        )
 set(INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATAROOTDIR}/cachemere")
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS cachemere EXPORT cachemere-targets)
 install(EXPORT cachemere-targets
-    DESTINATION "${INSTALL_CMAKEDIR}"
-    NAMESPACE cachemere::
-)
+        DESTINATION "${INSTALL_CMAKEDIR}"
+        NAMESPACE cachemere::
+        )
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cachemereConfig.cmake.in
-    ${PROJECT_BINARY_DIR}/cachemereConfig.cmake
-    INSTALL_DESTINATION "${INSTALL_CMAKEDIR}"
-)
+        ${PROJECT_BINARY_DIR}/cachemereConfig.cmake
+        INSTALL_DESTINATION "${INSTALL_CMAKEDIR}"
+        )
 install(FILES ${PROJECT_BINARY_DIR}/cachemereConfig.cmake DESTINATION ${INSTALL_CMAKEDIR})
 
 if (BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
-endif()
+endif ()
 
 if (BUILD_TESTS)
     add_subdirectory(tests)
-endif()
+endif ()
 
 target_sources(cachemere
-    INTERFACE
+        INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/cache.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/cache.hpp>
@@ -109,4 +116,4 @@ target_sources(cachemere
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/detail/counting_bloom_filter.hpp>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/detail/hash_mixer.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/policy/detail/hash_mixer.hpp>
-)
+        )

--- a/Doxyfile
+++ b/Doxyfile
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md implementingCustomPolicies.dox include/
+INPUT                  = README.md implementingCustomPolicies.dox heterogeneousLookup.dox include/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ as well as a comprehensive set of primitives for building custom caching solutio
 ![License](https://img.shields.io/github/license/coveooss/cachemere)
 
 ## Getting Started
+
 ### TinyLFU Cache
+
 ```cpp
 #include <cstdint>
 #include <optional>
@@ -46,33 +48,57 @@ int main()
 For more information, take a look at the [documentation](https://coveooss.github.io/cachemere/).
 
 ## Design Overview
+
 ### Background
-At its core, a cache has much in common with a hash map; both are data structures used for associating a key with a value.
-The main difference between the two structures is that a cache usually introduces an additional set of constraints to prevent it
+
+At its core, a cache has much in common with a hash map; both are data structures used for associating a key with a
+value.
+The main difference between the two structures is that a cache usually introduces an additional set of constraints to
+prevent it
 from growing too much in memory.
 Some implementations restrict the _number_ of items allowed at once in the cache, others restrict the
-total amount of _memory used_ by the cache, while some do away with the size constraints entirely and instead restrict the _amount of time_ an item can stay
+total amount of _memory used_ by the cache, while some do away with the size constraints entirely and instead restrict
+the _amount of time_ an item can stay
 in the cache before expiring.
 
 A **caching scheme** is the set of algorithms used to select which items should be kept in cache over others.
-Since many different metrics can be prioritized when implementing a cache, there is no _one-size-fits-all_ caching scheme (e.g. a CPU cache usually only needs to prioritize the cache hit ratio, while a web server cache also needs to consider latency on cache miss).
+Since many different metrics can be prioritized when implementing a cache, there is no _one-size-fits-all_ caching
+scheme (e.g. a CPU cache usually only needs to prioritize the cache hit ratio, while a web server cache also needs to
+consider latency on cache miss).
 
-Because of this impossiblity of relying on a single well-performing and reusable caching scheme, many organizations and products fall back on using a simple [Least-Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) cache everywhere. Although LRU is certainly _suitable_ for most use cases it is far from optimal, and using it without an afterthought might lead to excessive memory usage or degraded performance.
+Because of this impossiblity of relying on a single well-performing and reusable caching scheme, many organizations and
+products fall back on using a
+simple [Least-Recently Used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU))
+cache everywhere. Although LRU is certainly _suitable_ for most use cases it is far from optimal, and using it without
+an afterthought might lead to excessive memory usage or degraded performance.
 
-Cachemere is designed with the explicit goal of providing a single reusable cache that can be customized using different schemes, allowing applications to get the maintainability benefits of a single cache implementation, while at the same time getting all the performance benefits of a purpose-built cache.
+Cachemere is designed with the explicit goal of providing a single reusable cache that can be customized using different
+schemes, allowing applications to get the maintainability benefits of a single cache implementation, while at the same
+time getting all the performance benefits of a purpose-built cache.
 
 ### Modular Policy Design
 
 Cachemere tackles this goal in a modular fashion with the concept of _policies_. A `cachemere::Cache` is parameterized
 by a **Constraint Policy**, an **Insertion Policy**, and an **Eviction Policy**.
 
-Broadly speaking, the job of the **Constraint Policy** is to determine whether an item _can_ be in the cache (e.g. if there is enough free space), the job of an **Insertion Policy** is to determine whether an item should be inserted or kept in cache, while the job of an **Eviction
-Policy** is to determine which item(s) should be evicted from the cache. The cache will query its policies when it has to make a
+Broadly speaking, the job of the **Constraint Policy** is to determine whether an item _can_ be in the cache (e.g. if
+there is enough free space), the job of an **Insertion Policy** is to determine whether an item should be inserted or
+kept in cache, while the job of an **Eviction
+Policy** is to determine which item(s) should be evicted from the cache. The cache will query its policies when it has
+to make a
 decision on whether an item should be added or excluded.
 
-This modular design allows for bi-directional code reuse and customization: the core cache implementation can be used with different policies, and the
+This modular design allows for bi-directional code reuse and customization: the core cache implementation can be used
+with different policies, and the
 policies can also be used with different cache implementations.
 
 For instance, instead of using more common policies like Least-Recently Used (LRU),
 a product might need to use a custom cache that takes the frequency of access as well as the size of the item into
-consideration when establishing which item to evict. To do this, one could implement a `SizeBasedEvictionPolicy` and use it with the existing `cachemere::Cache`.
+consideration when establishing which item to evict. To do this, one could implement a `SizeBasedEvictionPolicy` and use
+it with the existing `cachemere::Cache`.
+
+### Heterogeneous Lookup
+
+Like `std::map`, `cachemere::Cache` supports heterogeneous lookup. Take a look
+at [the documentation on heterogeneous lookup](https://coveooss.github.io/cachemere/heterogeneousLookup.html) for more
+details and usage instructions.

--- a/benchmarks/accuracy/src/io_benchmark.cpp
+++ b/benchmarks/accuracy/src/io_benchmark.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -13,6 +12,7 @@
 #include <string>
 #include <thread>
 
+#include <absl/hash/hash.h>
 #include <tbb/concurrent_queue.h>
 
 #include "cachemere.h"
@@ -29,7 +29,7 @@ struct Article {
     Article(const std::string& uri)
     {
         // Seed the RNG with a hash of our URI, this way items will have the same size & latency every time.
-        std::minstd_rand rng{static_cast<std::minstd_rand::result_type>(std::hash<std::string>()(uri))};
+        std::minstd_rand rng{static_cast<std::minstd_rand::result_type>(absl::Hash<std::string>()(uri))};
 
         // Generate random sizes & latencies from two similarly-skewed gamma distributions.
         std::gamma_distribution<double> size_distribution{3, 0.8};

--- a/benchmarks/performance/CMakeLists.txt
+++ b/benchmarks/performance/CMakeLists.txt
@@ -3,17 +3,19 @@ find_package(benchmark REQUIRED)
 add_executable(bench_performance)
 
 target_link_libraries(bench_performance
-    PRIVATE
+        PRIVATE
         benchmark::benchmark
 
+        absl::hash
+
         cachemere
-)
+        )
 
 
 target_sources(bench_performance
-    PRIVATE
+        PRIVATE
         src/bench_cache.cpp
         src/main.cpp
-)
+        )
 
 add_compile_definitions(BENCHMARK_STATIC_DEFINE) # See https://stackoverflow.com/questions/73494386/lnk2001-linker-error-while-linking-google-benchmark-lib

--- a/benchmarks/performance/src/bench_cache.cpp
+++ b/benchmarks/performance/src/bench_cache.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <string>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere.h"
 
 using namespace cachemere;
@@ -15,7 +17,7 @@ struct Cost {
     }
 };
 
-template<typename Key, typename Value> using TestGDSF = policy::EvictionGDSF<Key, Value, Cost>;
+template<typename Key, typename KeyHash, typename Value> using TestGDSF = policy::EvictionGDSF<Key, KeyHash, Value, Cost>;
 
 #define CACHEMERE_POLICY_BENCH(test, insertion, eviction)                                                                        \
     BENCHMARK_TEMPLATE(test, insertion, eviction, true)->ArgsProduct({{1, 1000, 10000, 100000}})->Complexity()->UseManualTime(); \
@@ -29,7 +31,7 @@ template<typename Key, typename Value> using TestGDSF = policy::EvictionGDSF<Key
     CACHEMERE_POLICY_BENCH(test, policy::InsertionTinyLFU, policy::EvictionSegmentedLRU); \
     CACHEMERE_POLICY_BENCH(test, policy::InsertionTinyLFU, TestGDSF)
 
-template<template<class, class> class I, template<class, class> class E, bool ThreadSafe>
+template<template<class, class, class> class I, template<class, class, class> class E, bool ThreadSafe>
 using BenchCache = Cache<std::string,
                          std::string,
                          I,
@@ -37,6 +39,7 @@ using BenchCache = Cache<std::string,
                          policy::ConstraintMemory,
                          measurement::CapacityDynamicallyAllocated<std::string>,
                          measurement::CapacityDynamicallyAllocated<std::string>,
+                         absl::Hash<std::string>,
                          ThreadSafe>;
 
 template<class C> std::unique_ptr<C> setup(size_t item_count)
@@ -59,7 +62,8 @@ template<class C> std::unique_ptr<C> setup(size_t item_count)
     return cache;
 }
 
-template<template<class, class> class Insertion, template<class, class> class Eviction, bool ThreadSafe> void cache_insert(benchmark::State& state)
+template<template<class, class, class> class Insertion, template<class, class, class> class Eviction, bool ThreadSafe>
+void cache_insert(benchmark::State& state)
 {
     const size_t previous_insertions = state.range(0);
     auto         cache               = setup<BenchCache<Insertion, Eviction, ThreadSafe>>(previous_insertions);
@@ -82,7 +86,7 @@ template<template<class, class> class Insertion, template<class, class> class Ev
 
 CACHEMERE_BENCH(cache_insert);
 
-template<template<class, class> class Insertion, template<class, class> class Eviction, bool ThreadSafe> void cache_find(benchmark::State& state)
+template<template<class, class, class> class Insertion, template<class, class, class> class Eviction, bool ThreadSafe> void cache_find(benchmark::State& state)
 {
     const size_t previous_insertions = state.range(0);
     auto         cache               = setup<BenchCache<Insertion, Eviction, ThreadSafe>>(previous_insertions);

--- a/heterogeneousLookup.dox
+++ b/heterogeneousLookup.dox
@@ -1,0 +1,113 @@
+Using Heterogeneous Lookup {#heterogeneousLookup}
+============================
+
+This page is meant to guide you through the usage of heterogeneous lookup.
+
+## What is Heterogeneous Lookup and Why Should I Care?
+Heterogeneous lookup is the process of using a different key type for performing lookups in a set or in an associative container.
+It is mainly useful to help with performance in cases where it would be possible to construct a "cheaper" version of a key when performing lookups.
+
+Let's take a look at a small cache example _not_ using heterogeneous lookup to get a better grasp of the problem it addresses.
+
+## Typical Example (Cachemere < 0.3)
+```cpp
+#include <string>
+#include <cachemere.h>
+
+struct CompositeKey {
+    std::string first;
+    std::string second;
+    std::string third;
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeKey& s);
+    bool operator==(const CompositeKey& other) const;
+    size_t capacity() const;
+};
+
+using Value = std::string;
+
+using CacheT = cachemere::presets::memory::LRUCache<CompositeKey,
+                                                    Value,
+                                                    cachemere::measurement::CapacityDynamicallyAllocated<Value>,
+                                                    cachemere::measurement::CapacityDynamicallyAllocated<CompositeKey>>;
+
+
+bool contains(const CacheT& cache, std::string_view a, const std::string_view b, const std::string_view c) {
+    // We need allocate three strings to construct the key.
+    const std::string a_str{a};
+    const std::string b_str{b};
+    const std::string c_str{c};
+    const CompositeKey key{std::move(a_str), std::move(b_str), std::move(c_str)};
+
+    // Only to use a reference to it.
+    return cache.find(key).has_value();
+}
+
+int main() {
+    CacheT cache{1024 * 1024 * 1024};
+    cache.insert({"a", "b", "c"}, "some_value");
+
+    if (contains(cache, "a", "b", "c")) {
+        // [...]
+    }
+
+    return 0;
+}
+```
+
+In this example, we often need to allocate temporary strings, because we have no way of using a structure of `std::string_view` as a key.
+This is the problem that heterogeneous lookup solves. By using Cachemere's heterogeneous lookup primitives, one can use lightweight key types to do
+faster lookups in a cache.
+
+## Heterogeneous Lookup Example (Cachemere >= 0.3)
+```cpp
+#include <string>
+#include <cachemere.h>
+
+struct CompositeKey {
+    std::string first;
+    std::string second;
+    std::string third;
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeKey& s);
+    bool operator==(const CompositeKey& other) const;
+    size_t capacity() const;
+};
+
+struct CompositeView {
+    std::string_view a;
+    std::string_view b;
+    std::string_view c;
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeView& s);
+    bool operator==(const CompositeView& other) const;
+    bool operator==(const CompositeKey& other) const; // Key view must be comparable to the regular key.
+};
+
+// This hasher is able to hash both `CompositeKey` and `CompositeView`.
+using MultiHasher = cachemere::MultiHash<CompositeKey, absl::Hash<CompositeKey>, CompositeView, absl::Hash<CompositeView>>;
+using Value = std::string;
+
+using CacheT = cachemere::presets::memory::LRUCache<CompositeKey,
+                                                    Value,
+                                                    cachemere::measurement::CapacityDynamicallyAllocated<Value>,
+                                                    cachemere::measurement::CapacityDynamicallyAllocated<CompositeKey>,
+                                                    MultiHasher>;
+
+bool contains(const CacheT& cache, std::string_view a, const std::string_view b, const std::string_view c) {
+    // We can use the lightweight key directly, without allocating a single string.
+    const CompositeView key{a, b, c};
+    return cache.find(key).has_value();
+}
+
+int main() {
+    CacheT cache{1024 * 1024 * 1024};
+    cache.insert({"a", "b", "c"}, "some_value");
+
+    if (contains(cache, "a", "b", "c")) {
+        // [...]
+    }
+
+    return 0;
+}
+```

--- a/implementingCustomPolicies.dox
+++ b/implementingCustomPolicies.dox
@@ -22,8 +22,9 @@ The policies _may_ define the following event handlers to be notified of changes
 
     Called immediately after a cache hit (a successful call to `cachemere::Cache::find`).
 
-* `void on_cache_miss(K& key)`
+* `template<typename KeyType> void on_cache_miss(const KeyView& key)`
 
+    Where `KeyType` is a type that hashes to the same value as its corresponding `Key` using `KeyHash`.
     Called immediately after a cache miss (an unsuccessful call to `cachemere::Cache::find`).
 
 * `void on_evict(K& key)`

--- a/implementingCustomPolicies.dox
+++ b/implementingCustomPolicies.dox
@@ -5,6 +5,9 @@ This page is meant to guide you through the implementation of custom policies.
 ## Shared Characteristics
 ### Construction Requirements
 Insertion and eviction policies _must_ be [default-constructible](http://www.cplusplus.com/reference/type_traits/is_default_constructible/). The constraint policy may take parameters, these parameters will be forwarded to the policy from the cache constructor.
+### Template Parameters
+Cache policies are templates, which must take exactly three template parameters: `typename Key`, `typename KeyHash`, and `typename Value`.
+If a policy needs additional parameterization, `cachemere::policy::bind` can be used for partial specialization, allowing use with the cache.
 ### Event Handlers
 The policies _may_ define the following event handlers to be notified of changes in the cache. These handlers do not all need to be implemented; a policy only needs to define the handlers that are relevant to its implementation. The cache will detect available handlers on its policies at compile-time, and will only call those that are defined.
 * `void on_insert(K& key, cachemere::detail::Item<V>& item)`

--- a/include/cachemere.h
+++ b/include/cachemere.h
@@ -11,6 +11,7 @@
 #include "cachemere/policy/insertion_tinylfu.h"
 
 #include "cachemere/cache.h"
+#include "cachemere/hash.h"
 #include "cachemere/item.h"
 #include "cachemere/measurement.h"
 #include "cachemere/presets.h"

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -62,7 +62,8 @@ template<class K,
          class SK,
          class KH,
          bool TS>
-inline bool Cache<K, V, I, E, C, SV, SK, KH, TS>::contains(const K& key) const
+template<typename KeyView>
+inline bool Cache<K, V, I, E, C, SV, SK, KH, TS>::contains(const KeyView& key) const
 {
     LockGuard guard(lock());
     return m_data.find(key) != m_data.end();
@@ -80,7 +81,8 @@ template<class K,
          class SK,
          class KH,
          bool TS>
-std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, TS>::find(const K& key) const
+template<typename KeyView>
+std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, TS>::find(const KeyView& key) const
 {
     LockGuard guard(lock());
 
@@ -929,7 +931,8 @@ template<class K,
          class SK,
          class KH,
          bool TS>
-void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_miss(const K& key) const
+template<class KeyView>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_miss(const KeyView& key) const
 {
     // Update the cache hit rate accumulators.
     m_hit_rate_acc(0);

--- a/include/cachemere/cache.hpp
+++ b/include/cachemere/cache.hpp
@@ -2,20 +2,21 @@ namespace cachemere {
 
 template<typename Key,
          typename Value,
-         template<class, class>
+         template<class, class, class>
          class InsertionPolicy,
-         template<class, class>
+         template<class, class, class>
          class EvictionPolicy,
-         template<class, class>
+         template<class, class, class>
          class ConstraintPolicy,
          typename MeasureValue,
          typename MeasureKey,
+         typename KeyHash,
          bool ThreadSafe>
 template<typename... Args>
-Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, ThreadSafe>::Cache(Args... args)
- : m_insertion_policy(std::make_unique<InsertionPolicy<Key, Value>>()),
-   m_eviction_policy(std::make_unique<EvictionPolicy<Key, Value>>()),
-   m_constraint_policy(std::make_unique<ConstraintPolicy<Key, Value>>(std::forward<Args>(args)...)),
+Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, KeyHash, ThreadSafe>::Cache(Args... args)
+ : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
+   m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
+   m_constraint_policy(std::make_unique<MyConstraintPolicy>(std::forward<Args>(args)...)),
    m_mutex{},
    m_data{},
    m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
@@ -23,13 +24,24 @@ Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValu
 {
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<typename Coll, typename... Args>
-Cache<K, V, I, E, C, SV, SK, TS>::Cache(Coll& collection, std::tuple<Args...> args)
- : m_insertion_policy(std::make_unique<I<K, V>>()),
-   m_eviction_policy(std::make_unique<E<K, V>>()),
-   m_constraint_policy(
-       std::move(std::apply([](auto&&... params) { return std::make_unique<C<K, V>>(std::forward<decltype(params)>(params)...); }, std::move(args)))),
+Cache<K, V, I, E, C, SV, SK, KH, TS>::Cache(Coll& collection, std::tuple<Args...> args)
+ : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
+   m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
+   m_constraint_policy(std::move(
+       std::apply([](auto&&... params) { return std::make_unique<MyConstraintPolicy>(std::forward<decltype(params)>(params)...); }, std::move(args)))),
    m_mutex{},
    m_data{},
    m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
@@ -38,15 +50,37 @@ Cache<K, V, I, E, C, SV, SK, TS>::Cache(Coll& collection, std::tuple<Args...> ar
     import(collection);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline bool Cache<K, V, I, E, C, SV, SK, TS>::contains(const K& key) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline bool Cache<K, V, I, E, C, SV, SK, KH, TS>::contains(const K& key) const
 {
     LockGuard guard(lock());
     return m_data.find(key) != m_data.end();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, TS>::find(const K& key) const
 {
     LockGuard guard(lock());
 
@@ -60,9 +94,20 @@ std::optional<V> Cache<K, V, I, E, C, SV, SK, TS>::find(const K& key) const
     return std::nullopt;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<class Container>
-void Cache<K, V, I, E, C, SV, SK, TS>::collect_into(Container& container) const
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::collect_into(Container& container) const
 {
     using namespace detail;
 
@@ -86,8 +131,19 @@ void Cache<K, V, I, E, C, SV, SK, TS>::collect_into(Container& container) const
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, C, SV, SK, TS>::insert(K key, V value)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+bool Cache<K, V, I, E, C, SV, SK, KH, TS>::insert(K key, V value)
 {
     LockGuard guard(lock());
 
@@ -116,8 +172,19 @@ bool Cache<K, V, I, E, C, SV, SK, TS>::insert(K key, V value)
     return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, C, SV, SK, TS>::remove(const K& key)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+bool Cache<K, V, I, E, C, SV, SK, KH, TS>::remove(const K& key)
 {
     LockGuard guard(lock());
 
@@ -129,8 +196,19 @@ bool Cache<K, V, I, E, C, SV, SK, TS>::remove(const K& key)
     return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::clear()
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::clear()
 {
     LockGuard guard(lock());
 
@@ -144,9 +222,20 @@ void Cache<K, V, I, E, C, SV, SK, TS>::clear()
     m_constraint_policy->clear();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<class P>
-void Cache<K, V, I, E, C, SV, SK, TS>::retain(P predicate_fn)
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::retain(P predicate_fn)
 {
     LockGuard guard(lock());
 
@@ -161,9 +250,20 @@ void Cache<K, V, I, E, C, SV, SK, TS>::retain(P predicate_fn)
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<class F>
-void Cache<K, V, I, E, C, SV, SK, TS>::for_each(F unary_function)
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::for_each(F unary_function)
 {
     LockGuard guard(lock());
     for (const auto& [key, value] : m_data) {
@@ -171,8 +271,19 @@ void Cache<K, V, I, E, C, SV, SK, TS>::for_each(F unary_function)
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::swap(CacheType& other) noexcept
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::swap(CacheType& other) noexcept
 {
     try {
         // Acquire both cache locks.
@@ -208,16 +319,38 @@ void Cache<K, V, I, E, C, SV, SK, TS>::swap(CacheType& other) noexcept
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline size_t Cache<K, V, I, E, C, SV, SK, TS>::number_of_items() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline size_t Cache<K, V, I, E, C, SV, SK, KH, TS>::number_of_items() const
 {
     LockGuard guard(lock());
     return m_data.size();
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<typename... Args>
-void Cache<K, V, I, E, C, SV, SK, TS>::update_constraint(Args... args)
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::update_constraint(Args... args)
 {
     LockGuard guard(lock());
     m_constraint_policy->update(std::forward<Args>(args)...);
@@ -239,62 +372,172 @@ void Cache<K, V, I, E, C, SV, SK, TS>::update_constraint(Args... args)
     assert(m_constraint_policy->is_satisfied());
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline I<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::insertion_policy()
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::insertion_policy() -> MyInsertionPolicy&
 {
     return *m_insertion_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline const I<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::insertion_policy() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::insertion_policy() const -> const MyInsertionPolicy&
 {
     return *m_insertion_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline E<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::eviction_policy()
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::eviction_policy() -> MyEvictionPolicy&
 {
     return *m_eviction_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline const E<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::eviction_policy() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::eviction_policy() const -> const MyEvictionPolicy&
 {
     return *m_eviction_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline C<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::constraint_policy()
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::constraint_policy() -> MyConstraintPolicy&
 {
     return *m_constraint_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline const C<K, V>& Cache<K, V, I, E, C, SV, SK, TS>::constraint_policy() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::constraint_policy() const -> const MyConstraintPolicy&
 {
     return *m_constraint_policy;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline double Cache<K, V, I, E, C, SV, SK, TS>::hit_rate() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline double Cache<K, V, I, E, C, SV, SK, KH, TS>::hit_rate() const
 {
     return boost::accumulators::rolling_mean(m_hit_rate_acc);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline double Cache<K, V, I, E, C, SV, SK, TS>::byte_hit_rate() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline double Cache<K, V, I, E, C, SV, SK, KH, TS>::byte_hit_rate() const
 {
     return boost::accumulators::rolling_mean(m_byte_hit_rate_acc);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline uint32_t Cache<K, V, I, E, C, SV, SK, TS>::statistics_window_size() const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline uint32_t Cache<K, V, I, E, C, SV, SK, KH, TS>::statistics_window_size() const
 {
     return m_statistics_window_size;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-inline void Cache<K, V, I, E, C, SV, SK, TS>::statistics_window_size(uint32_t window_size)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+inline void Cache<K, V, I, E, C, SV, SK, KH, TS>::statistics_window_size(uint32_t window_size)
 {
     m_statistics_window_size = window_size;
 
@@ -302,8 +545,19 @@ inline void Cache<K, V, I, E, C, SV, SK, TS>::statistics_window_size(uint32_t wi
     m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-auto Cache<K, V, I, E, C, SV, SK, TS>::lock() const -> LockGuard
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock() const -> LockGuard
 {
     if constexpr (TS) {
         LockGuard guard{m_mutex};
@@ -314,8 +568,19 @@ auto Cache<K, V, I, E, C, SV, SK, TS>::lock() const -> LockGuard
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-auto Cache<K, V, I, E, C, SV, SK, TS>::lock([[maybe_unused]] std::defer_lock_t defer_lock_tag) const -> LockGuard
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock([[maybe_unused]] std::defer_lock_t defer_lock_tag) const -> LockGuard
 {
     if constexpr (TS) {
         LockGuard guard{m_mutex, defer_lock_tag};
@@ -326,8 +591,19 @@ auto Cache<K, V, I, E, C, SV, SK, TS>::lock([[maybe_unused]] std::defer_lock_t d
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-auto Cache<K, V, I, E, C, SV, SK, TS>::lock_pair(CacheType& other) const -> std::pair<LockGuard, LockGuard>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock_pair(CacheType& other) const -> std::pair<LockGuard, LockGuard>
 {
     LockGuard my_guard    = lock(std::defer_lock);
     LockGuard other_guard = other.lock(std::defer_lock);
@@ -339,9 +615,20 @@ auto Cache<K, V, I, E, C, SV, SK, TS>::lock_pair(CacheType& other) const -> std:
     return std::make_pair<LockGuard, LockGuard>(std::move(my_guard), std::move(other_guard));
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 template<class Coll>
-void Cache<K, V, I, E, C, SV, SK, TS>::import(Coll& collection)
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::import(Coll& collection)
 {
     LockGuard guard(lock());
 
@@ -358,8 +645,19 @@ void Cache<K, V, I, E, C, SV, SK, TS>::import(Coll& collection)
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, C, SV, SK, TS>::check_insert(const K& key, const CacheItem& item)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_insert(const K& key, const CacheItem& item)
 {
     if (m_constraint_policy->can_add(key, item)) {
         return m_insertion_policy->should_add(key);
@@ -406,8 +704,19 @@ bool Cache<K, V, I, E, C, SV, SK, TS>::check_insert(const K& key, const CacheIte
     return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-bool Cache<K, V, I, E, C, SV, SK, TS>::check_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item)
 {
     if (m_constraint_policy->can_replace(key, old_item, new_item)) {
         return true;
@@ -466,8 +775,19 @@ bool Cache<K, V, I, E, C, SV, SK, TS>::check_replace(const K& key, const CacheIt
     return false;
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::insert_or_update(K&& key, CacheItem&& item)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::insert_or_update(K&& key, CacheItem&& item)
 {
     auto key_and_item = m_data.find(key);
     if (key_and_item != m_data.end()) {
@@ -482,55 +802,99 @@ void Cache<K, V, I, E, C, SV, SK, TS>::insert_or_update(K&& key, CacheItem&& ite
     }
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::remove(DataMapIt it)
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::remove(DataMapIt it)
 {
     on_evict(it->first, it->second);
     m_data.erase(it);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::on_insert(const K& key, const CacheItem& item) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_insert(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
-        detail::traits::event::has_on_insert<K, V, I>,
+        detail::traits::event::has_on_insert<K, KH, V, I>,
         [&](auto& x) { return x.on_insert(key, item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_insert<K, V, E>,
+        detail::traits::event::has_on_insert<K, KH, V, E>,
         [&](auto& x) { return x.on_insert(key, item); },
         [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_insert<K, V, C>,
+        detail::traits::event::has_on_insert<K, KH, V, C>,
         [&](auto& x) { return x.on_insert(key, item); },
         [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::on_update(const K& key, const CacheItem& old_item, const CacheItem& new_item) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_update(const K& key, const CacheItem& old_item, const CacheItem& new_item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
-        detail::traits::event::has_on_update<K, V, I>,
+        detail::traits::event::has_on_update<K, KH, V, I>,
         [&](auto& x) { return x.on_update(key, old_item, new_item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_update<K, V, E>,
+        detail::traits::event::has_on_update<K, KH, V, E>,
         [&](auto& x) { return x.on_update(key, old_item, new_item); },
         [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_update<K, V, C>,
+        detail::traits::event::has_on_update<K, KH, V, C>,
         [&](auto& x) { return x.on_update(key, old_item, new_item); },
         [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_hit(const K& key, const CacheItem& item) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_hit(const K& key, const CacheItem& item) const
 {
     // Update the cache hit rate accumulators.
     m_hit_rate_acc(1);
@@ -538,23 +902,34 @@ void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_hit(const K& key, const CacheIte
 
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
-        detail::traits::event::has_on_cachehit<K, V, I>,
+        detail::traits::event::has_on_cachehit<K, KH, V, I>,
         [&](auto& x) { return x.on_cache_hit(key, item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_cachehit<K, V, E>,
+        detail::traits::event::has_on_cachehit<K, KH, V, E>,
         [&](auto& x) { return x.on_cache_hit(key, item); },
         [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_cachehit<K, V, E>,
+        detail::traits::event::has_on_cachehit<K, KH, V, E>,
         [&](auto& x) { return x.on_cache_hit(key, item); },
         [](auto&) {})(*m_eviction_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_miss(const K& key) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_miss(const K& key) const
 {
     // Update the cache hit rate accumulators.
     m_hit_rate_acc(0);
@@ -562,43 +937,65 @@ void Cache<K, V, I, E, C, SV, SK, TS>::on_cache_miss(const K& key) const
 
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, V, I>,
+        detail::traits::event::has_on_cachemiss<K, KH, V, I>,
         [&](auto& x) { return x.on_cache_miss(key); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, V, E>,
+        detail::traits::event::has_on_cachemiss<K, KH, V, E>,
         [&](auto& x) { return x.on_cache_miss(key); },
         [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, V, C>,
+        detail::traits::event::has_on_cachemiss<K, KH, V, C>,
         [&](auto& x) { return x.on_cache_miss(key); },
         [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void Cache<K, V, I, E, C, SV, SK, TS>::on_evict(const K& key, const CacheItem& item) const
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_evict(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
     boost::hana::if_(
-        detail::traits::event::has_on_evict<K, V, I>,
+        detail::traits::event::has_on_evict<K, KH, V, I>,
         [&](auto& x) { return x.on_evict(key, item); },
         [](auto&) {})(*m_insertion_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_evict<K, V, E>,
+        detail::traits::event::has_on_evict<K, KH, V, E>,
         [&](auto& x) { return x.on_evict(key, item); },
         [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_evict<K, V, C>,
+        detail::traits::event::has_on_evict<K, KH, V, C>,
         [&](auto& x) { return x.on_evict(key, item); },
         [](auto&) {})(*m_constraint_policy);
 }
 
-template<class K, class V, template<class, class> class I, template<class, class> class E, template<class, class> class C, class SV, class SK, bool TS>
-void swap(Cache<K, V, I, E, C, SV, SK, TS>& lhs, Cache<K, V, I, E, C, SV, SK, TS>& rhs) noexcept
+template<class K,
+         class V,
+         template<class, class, class>
+         class I,
+         template<class, class, class>
+         class E,
+         template<class, class, class>
+         class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void swap(Cache<K, V, I, E, C, SV, SK, KH, TS>& lhs, Cache<K, V, I, E, C, SV, SK, KH, TS>& rhs) noexcept
 {
     lhs.swap(rhs);
 }

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -9,50 +9,50 @@ namespace cachemere::detail::traits {
 namespace stl {
 
 template<typename T>
-constexpr auto has_reserve = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).reserve(std::declval<size_t>())) {
-})(boost::hana::type_c<T>);
+constexpr auto has_reserve =
+    boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).reserve(std::declval<size_t>())) {})(boost::hana::type_c<T>);
 
 template<typename T>
 constexpr auto has_size = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).size()) {})(boost::hana::type_c<T>);
 
 template<typename T, typename... Args>
-constexpr auto has_emplace_back = boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).emplace_back(std::declval<Args>()...)) {
-})(boost::hana::type_c<T>);
+constexpr auto has_emplace_back =
+    boost::hana::is_valid([](auto& t) -> decltype(boost::hana::traits::declval(t).emplace_back(std::declval<Args>()...)) {})(boost::hana::type_c<T>);
 
 }  // namespace stl
 
 // Traits for cache event handlers.
 namespace event {
 
-template<typename K, typename V, template<class, class> typename P>
+template<typename K, typename KH, typename V, template<class, class, class> typename P>
 constexpr auto has_on_insert = boost::hana::is_valid(
     [](auto& policy_t, auto& key_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_insert(boost::hana::traits::declval(key_t),
                                                                                                                boost::hana::traits::declval(item_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
+    })(boost::hana::type_c<P<K, KH, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
-template<typename K, typename V, template<class, class> typename P>
+template<typename K, typename KH, typename V, template<class, class, class> typename P>
 constexpr auto has_on_update = boost::hana::is_valid(
     [](auto& policy_t, auto& key_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_update(boost::hana::traits::declval(key_t),
                                                                                                                boost::hana::traits::declval(item_t),
                                                                                                                boost::hana::traits::declval(item_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
+    })(boost::hana::type_c<P<K, KH, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
-template<typename K, typename V, template<class, class> typename P>
+template<typename K, typename KH, typename V, template<class, class, class> typename P>
 constexpr auto has_on_cachehit = boost::hana::is_valid(
     [](auto& policy_t, auto& key_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_cache_hit(boost::hana::traits::declval(key_t),
                                                                                                                   boost::hana::traits::declval(item_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
+    })(boost::hana::type_c<P<K, KH, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
-template<typename K, typename V, template<class, class> typename P>
+template<typename K, typename KH, typename V, template<class, class, class> typename P>
 constexpr auto has_on_cachemiss = boost::hana::is_valid(
     [](auto& policy_t, auto& item_t) -> decltype(boost::hana::traits::declval(policy_t).on_cache_miss(boost::hana::traits::declval(item_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>);
+    })(boost::hana::type_c<P<K, KH, V>>, boost::hana::type_c<K>);
 
-template<typename K, typename V, template<class, class> typename P>
+template<typename K, typename KH, typename V, template<class, class, class> typename P>
 constexpr auto has_on_evict = boost::hana::is_valid(
     [](auto& policy_t, auto& key_t, auto& value_t) -> decltype(boost::hana::traits::declval(policy_t).on_evict(boost::hana::traits::declval(key_t),
                                                                                                                boost::hana::traits::declval(value_t))) {
-    })(boost::hana::type_c<P<K, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
+    })(boost::hana::type_c<P<K, KH, V>>, boost::hana::type_c<K>, boost::hana::type_c<Item<V>>);
 
 }  // namespace event
 

--- a/include/cachemere/detail/transparent_eq.h
+++ b/include/cachemere/detail/transparent_eq.h
@@ -1,0 +1,32 @@
+#ifndef CACHEMERE_TRANSPARENT_EQ_H
+#define CACHEMERE_TRANSPARENT_EQ_H
+
+#include <absl/hash/hash.h>
+
+namespace cachemere::detail {
+
+template<typename Key> struct TransparentEq {
+    // Declare this type as transparent - this is needed for abseil maps to support heterogeneous lookup.
+    using is_transparent = void;
+
+    bool operator()(const Key& a, const Key& b) const
+    {
+        return a == b;
+    }
+
+    template<typename KeyView> bool operator()(const Key& a, const KeyView& b) const
+    {
+        // We only require operator==(const Key&) to be defined on the KeyView.
+        return b == a;
+    }
+
+    template<typename KeyView> bool operator()(const KeyView& a, const Key& b) const
+    {
+        // We only require operator==(const Key&) to be defined on the KeyView.
+        return a == b;
+    }
+};
+
+}  // namespace cachemere::detail
+
+#endif  // CACHEMERE_TRANSPARENT_EQ_H

--- a/include/cachemere/hash.h
+++ b/include/cachemere/hash.h
@@ -1,0 +1,39 @@
+#ifndef CACHEMERE_HASH_H
+#define CACHEMERE_HASH_H
+
+#include <cstdint>
+
+namespace cachemere {
+
+/// @brief Allows combining hashers for multiple types into a single hashing object.
+/// @details Takes pairs of template parameters of the form [(T, Hash<T>), (U, Hash<U>), ...] and generates an override of the call operator to hash that
+///        particular type using its hasher.
+template<typename Key, typename KeyHash, typename... Tail> struct MultiHash;
+
+// Base case.
+template<typename Key, typename KeyHash> struct MultiHash<Key, KeyHash> {
+    // Declare this type as transparent - this is needed for abseil maps to support heterogeneous lookup.
+    using is_transparent = void;
+
+    size_t operator()(const Key& key) const
+    {
+        return m_hash(key);
+    }
+
+private:
+    KeyHash m_hash;
+};
+
+// Recursive case.
+template<typename Key, typename KeyHash, typename... Tail> struct MultiHash : public MultiHash<Key, KeyHash>, public MultiHash<Tail...> {
+    // Declare this type as transparent - this is needed for abseil maps to support heterogeneous lookup.
+    using is_transparent = void;
+
+    // Need to bring back operator() declarations from parent types, so they can all be considered as overloads.
+    using MultiHash<Key, KeyHash>::operator();
+    using MultiHash<Tail...>::     operator();
+};
+
+}  // namespace cachemere
+
+#endif  // CACHEMERE_HASH_H

--- a/include/cachemere/policy/bind.h
+++ b/include/cachemere/policy/bind.h
@@ -3,9 +3,9 @@
 
 namespace cachemere::policy {
 
-/// @brief Binds a `Policy<K, V, Args...>` template to a `Policy<K, V>` template to be used with the cache.
+/// @brief Binds a `Policy<K, KH, V, Args...>` template to a `Policy<K, KH, V>` template to be used with the cache.
 template<template<typename...> class Policy, typename... Args> struct bind {
-    template<typename K, typename V> using ttype = Policy<K, V, Args...>;
+    template<typename K, typename KH, typename V> using ttype = Policy<K, KH, V, Args...>;
 };
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -8,8 +8,9 @@ namespace cachemere::policy {
 /// @brief Count constraint.
 /// @details Use this when the constraint of the cache should be the number of items in cache.
 /// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename Value> class ConstraintCount
+template<typename Key, typename KeyHash, typename Value> class ConstraintCount
 {
     using CacheItem = Item<Value>;
 
@@ -58,11 +59,11 @@ public:
 
     /// @brief Get the number of items currently in the cache.
     /// @return The number of items in cache.
-    size_t count() const;
+    [[nodiscard]] size_t count() const;
 
     /// @brief Get the maximum number of items allowed in cache.
     /// @return The maximum number of items allowed in cache.
-    size_t maximum_count() const;
+    [[nodiscard]] size_t maximum_count() const;
 
 private:
     size_t m_maximum_count;

--- a/include/cachemere/policy/constraint_count.hpp
+++ b/include/cachemere/policy/constraint_count.hpp
@@ -1,21 +1,22 @@
 namespace cachemere::policy {
 
-template<typename K, typename V> ConstraintCount<K, V>::ConstraintCount(size_t maximum_count)
+template<class K, class KH, class V> ConstraintCount<K, KH, V>::ConstraintCount(size_t maximum_count)
 {
     update(maximum_count);
 }
 
-template<typename K, typename V> void ConstraintCount<K, V>::clear()
+template<class K, class KH, class V> void ConstraintCount<K, KH, V>::clear()
 {
     m_count = 0;
 }
 
-template<typename K, typename V> bool ConstraintCount<K, V>::can_add(const K& /* key */, const CacheItem& /* item */)
+template<class K, class KH, class V> bool ConstraintCount<K, KH, V>::can_add(const K& /* key */, const CacheItem& /* item */)
 {
     return m_count < m_maximum_count;
 }
 
-template<typename K, typename V> bool ConstraintCount<K, V>::can_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */)
+template<class K, class KH, class V>
+bool ConstraintCount<K, KH, V>::can_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */)
 {
     assert(m_count > 0);
 
@@ -23,33 +24,33 @@ template<typename K, typename V> bool ConstraintCount<K, V>::can_replace(const K
     return true;
 }
 
-template<typename K, typename V> bool ConstraintCount<K, V>::is_satisfied()
+template<class K, class KH, class V> bool ConstraintCount<K, KH, V>::is_satisfied()
 {
     return m_count <= m_maximum_count;
 }
 
-template<typename K, typename V> void ConstraintCount<K, V>::update(size_t maximum_count)
+template<class K, class KH, class V> void ConstraintCount<K, KH, V>::update(size_t maximum_count)
 {
     m_maximum_count = maximum_count;
 }
 
-template<typename K, typename V> void ConstraintCount<K, V>::on_insert(const K& /* key */, const CacheItem& /* item */)
+template<class K, class KH, class V> void ConstraintCount<K, KH, V>::on_insert(const K& /* key */, const CacheItem& /* item */)
 {
     ++m_count;
 }
 
-template<typename K, typename V> void ConstraintCount<K, V>::on_evict(const K& /* key */, const CacheItem& /* item */)
+template<class K, class KH, class V> void ConstraintCount<K, KH, V>::on_evict(const K& /* key */, const CacheItem& /* item */)
 {
     assert(m_count > 0);
     --m_count;
 }
 
-template<typename K, typename V> size_t ConstraintCount<K, V>::count() const
+template<class K, class KH, class V> size_t ConstraintCount<K, KH, V>::count() const
 {
     return m_count;
 }
 
-template<typename K, typename V> size_t ConstraintCount<K, V>::maximum_count() const
+template<class K, class KH, class V> size_t ConstraintCount<K, KH, V>::maximum_count() const
 {
     return m_maximum_count;
 }

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -8,8 +8,9 @@ namespace cachemere::policy {
 /// @brief Memory constraint.
 /// @details Use this when the constraint of the cache should be how many bytes of memory it uses.
 /// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename Value> class ConstraintMemory
+template<typename Key, typename KeyHash, typename Value> class ConstraintMemory
 {
     using CacheItem = Item<Value>;
 

--- a/include/cachemere/policy/constraint_memory.hpp
+++ b/include/cachemere/policy/constraint_memory.hpp
@@ -1,60 +1,60 @@
 namespace cachemere::policy {
 
-template<typename K, typename V> ConstraintMemory<K, V>::ConstraintMemory(size_t max_memory)
+template<class K, class KH, class V> ConstraintMemory<K, KH, V>::ConstraintMemory(size_t max_memory)
 {
     update(max_memory);
 }
 
-template<typename K, typename V> void ConstraintMemory<K, V>::clear()
+template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::clear()
 {
     m_memory = 0;
 }
 
-template<typename K, typename V> bool ConstraintMemory<K, V>::can_add(const K& /* key */, const CacheItem& item)
+template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::can_add(const K& /* key */, const CacheItem& item)
 {
     return (m_memory + item.m_total_size) <= m_maximum_memory;
 }
 
-template<typename K, typename V> bool ConstraintMemory<K, V>::can_replace(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::can_replace(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
 {
     assert(old_item.m_key_size == new_item.m_key_size);  // Key size *really* shouldn't have changed since the key is supposed to be const.
     return ((m_memory - old_item.m_value_size) + new_item.m_value_size) <= m_maximum_memory;
 }
 
-template<typename K, typename V> bool ConstraintMemory<K, V>::is_satisfied()
+template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::is_satisfied()
 {
     return m_memory <= m_maximum_memory;
 }
 
-template<typename K, typename V> void ConstraintMemory<K, V>::update(size_t max_memory)
+template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::update(size_t max_memory)
 {
     m_maximum_memory = max_memory;
 }
 
-template<typename K, typename V> size_t ConstraintMemory<K, V>::memory() const
+template<class K, class KH, class V> size_t ConstraintMemory<K, KH, V>::memory() const
 {
     return m_memory;
 }
 
-template<typename K, typename V> size_t ConstraintMemory<K, V>::maximum_memory() const
+template<class K, class KH, class V> size_t ConstraintMemory<K, KH, V>::maximum_memory() const
 {
     return m_maximum_memory;
 }
 
-template<typename K, typename V> void ConstraintMemory<K, V>::on_insert(const K& /* key */, const CacheItem& item)
+template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_insert(const K& /* key */, const CacheItem& item)
 {
     m_memory += item.m_total_size;
     assert(m_memory <= m_maximum_memory);
 }
 
-template<typename K, typename V> void ConstraintMemory<K, V>::on_update(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_update(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
 {
     m_memory -= old_item.m_value_size;
     m_memory += new_item.m_value_size;
     assert(m_memory <= m_maximum_memory);
 }
 
-template<typename K, typename V> void ConstraintMemory<K, V>::on_evict(const K& /* key */, const CacheItem& item)
+template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_evict(const K& /* key */, const CacheItem& item)
 {
     assert(item.m_total_size <= m_memory);
     m_memory -= item.m_total_size;

--- a/include/cachemere/policy/detail/bloom_filter.h
+++ b/include/cachemere/policy/detail/bloom_filter.h
@@ -12,6 +12,7 @@
 #endif
 
 #include <boost/dynamic_bitset.hpp>
+#include <absl/hash/hash.h>
 
 #ifdef _WIN32
 #    pragma warning(pop)
@@ -27,7 +28,7 @@ namespace cachemere::policy::detail {
 ///          filter membership tests.
 /// @tparam Item The type of the items that will be inserted into the set.
 /// @tparam ItemHash Functor used for hashing the items inserted in the set.
-template<typename Item, typename ItemHash = std::hash<Item>> class BloomFilter
+template<typename Item, typename ItemHash = absl::Hash<Item>> class BloomFilter
 {
 public:
     /// @brief Constructor.

--- a/include/cachemere/policy/detail/bloom_filter.h
+++ b/include/cachemere/policy/detail/bloom_filter.h
@@ -12,7 +12,6 @@
 #endif
 
 #include <boost/dynamic_bitset.hpp>
-#include <absl/hash/hash.h>
 
 #ifdef _WIN32
 #    pragma warning(pop)
@@ -26,9 +25,8 @@ namespace cachemere::policy::detail {
 /// @details A bloom filter is a constant-sized data structure, which means that insertions will never make
 ///          the filter allocate more memory. However, too many inserts will severly impact the accuracy of
 ///          filter membership tests.
-/// @tparam Item The type of the items that will be inserted into the set.
 /// @tparam ItemHash Functor used for hashing the items inserted in the set.
-template<typename Item, typename ItemHash = absl::Hash<Item>> class BloomFilter
+template<typename ItemHash> class BloomFilter
 {
 public:
     /// @brief Constructor.
@@ -43,7 +41,7 @@ public:
 
     /// @brief Add an item to the filter.
     /// @param item The item to insert.
-    void add(const Item& item);
+    template<typename ItemKey> void add(const ItemKey& item);
 
     /// @brief Clear the filter while keeping the allocated memory.
     void clear();
@@ -53,7 +51,7 @@ public:
     ///          This method returning `true` only means that the set _might_ contain the specified item,
     ///          while a return value of `false` means that the set _certainly_ does not contain the specified item.
     /// @param item The item to test.
-    [[nodiscard]] bool maybe_contains(const Item& item) const;
+    template<typename ItemKey> [[nodiscard]] bool maybe_contains(const ItemKey& item) const;
 
     /// @brief Get an estimate of the memory consumption of the filter.
     /// @return The memory used by the filter, in bytes.
@@ -67,7 +65,6 @@ public:
     [[nodiscard]] double saturation() const noexcept;
 
 private:
-    using Mixer       = HashMixer<Item, ItemHash>;
     using BitsetBlock = uint8_t;
     using BitSet      = boost::dynamic_bitset<BitsetBlock>;
 

--- a/include/cachemere/policy/detail/counting_bloom_filter.h
+++ b/include/cachemere/policy/detail/counting_bloom_filter.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include <vector>
 
+#include <absl/hash/hash.h>
+
 #include "hash_mixer.h"
 
 namespace cachemere::policy::detail {
@@ -13,7 +15,7 @@ namespace cachemere::policy::detail {
 /// @details A counting bloom filter is a constant-sized data structure, which means that insertions will never
 ///          make the filter allocate more memory. However, too many inserts will severly impact the accuracy
 ///          of counter estimates.
-template<typename Item, typename ItemHash = std::hash<Item>> class CountingBloomFilter
+template<typename Item, typename ItemHash = absl::Hash<Item>> class CountingBloomFilter
 {
 public:
     /// @brief Constructor.

--- a/include/cachemere/policy/detail/counting_bloom_filter.h
+++ b/include/cachemere/policy/detail/counting_bloom_filter.h
@@ -10,12 +10,12 @@
 
 namespace cachemere::policy::detail {
 
-/// @brief Space-efficient probalistic data structure to estimate the number of times
+/// @brief Space-efficient probabilistic data structure to estimate the number of times
 ///        an item was inserted in a set.
 /// @details A counting bloom filter is a constant-sized data structure, which means that insertions will never
-///          make the filter allocate more memory. However, too many inserts will severly impact the accuracy
+///          make the filter allocate more memory. However, too many inserts will severely impact the accuracy
 ///          of counter estimates.
-template<typename Item, typename ItemHash = absl::Hash<Item>> class CountingBloomFilter
+template<typename ItemHash> class CountingBloomFilter
 {
 public:
     /// @brief Constructor.
@@ -30,7 +30,7 @@ public:
 
     /// @brief Increment the count for a given item by one.
     /// @param item The item of the counter to increment.
-    void add(const Item& item);
+    template<typename ItemKey> void add(const ItemKey& item);
 
     /// @brief Clear the filter while keeping the allocated memory.
     void clear();
@@ -48,7 +48,7 @@ public:
     ///          the real counter value - the real count is guaranteed to be less or equal to the estimate
     ///          returned.
     /// @return The counter estimate for the item.
-    [[nodiscard]] uint32_t estimate(const Item& item) const;
+    template<typename ItemKey> [[nodiscard]] uint32_t estimate(const ItemKey& item) const;
 
     /// @brief Get the cardinality of the filter.
     /// @return The cardinality of the filter, as configured.
@@ -67,8 +67,6 @@ public:
     [[nodiscard]] double saturation() const noexcept;
 
 private:
-    using Mixer = HashMixer<Item, ItemHash>;
-
     uint32_t              m_cardinality;
     std::vector<uint32_t> m_filter;
     uint32_t              m_nb_hashes;

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -105,9 +105,9 @@ public:
 private:
     using IteratorMap = absl::btree_map<KeyRef, PrioritySetIt, std::less<const Key>>;
 
-    const static uint32_t            DEFAULT_CACHE_CARDINALITY = 2000;               // The expected cache cardinality, for the counting bloom filter.
-    mutable Cost                     m_measure_cost;                                 // The functor to measure the cost metric of cached items.
-    detail::CountingBloomFilter<Key> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with a count-min sketch to get rid of cardinality
+    const static uint32_t                DEFAULT_CACHE_CARDINALITY = 2000;               // The expected cache cardinality, for the counting bloom filter.
+    mutable Cost                         m_measure_cost;                                 // The functor to measure the cost metric of cached items.
+    detail::CountingBloomFilter<KeyHash> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with a count-min sketch to get rid of cardinality
 
     PrioritySet m_priority_set;  // A multiset of keys sorted by H-coefficients in ascending order.
 

--- a/include/cachemere/policy/eviction_gdsf.hpp
+++ b/include/cachemere/policy/eviction_gdsf.hpp
@@ -1,60 +1,63 @@
 namespace cachemere::policy {
 
-template<class Key, class Value, class Cost>
-EvictionGDSF<Key, Value, Cost>::PriorityEntry::PriorityEntry(KeyRef key, double coefficient) : m_key(key),
-                                                                                               m_h_coefficient(coefficient)
+template<class Key, class KeyHash, class Value, class Cost>
+EvictionGDSF<Key, KeyHash, Value, Cost>::PriorityEntry::PriorityEntry(KeyRef key, double coefficient) : m_key(key),
+                                                                                                        m_h_coefficient(coefficient)
 {
 }
 
-template<class Key, class Value, class Cost> bool EvictionGDSF<Key, Value, Cost>::PriorityEntry::operator<(const PriorityEntry& other) const
+template<class Key, class KeyHash, class Value, class Cost>
+bool EvictionGDSF<Key, KeyHash, Value, Cost>::PriorityEntry::operator<(const PriorityEntry& other) const
 {
     return m_h_coefficient < other.m_h_coefficient;
 }
 
-template<class Key, class Value, class Cost>
-EvictionGDSF<Key, Value, Cost>::VictimIterator::VictimIterator(PrioritySetIt iterator) : m_iterator(std::move(iterator))
+template<class Key, class KeyHash, class Value, class Cost>
+EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::VictimIterator(PrioritySetIt iterator) : m_iterator(std::move(iterator))
 {
 }
 
-template<class Key, class Value, class Cost> const Key& EvictionGDSF<Key, Value, Cost>::VictimIterator::operator*() const
+template<class Key, class KeyHash, class Value, class Cost> const Key& EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator*() const
 {
     return m_iterator->m_key;
 }
 
-template<class Key, class Value, class Cost> auto EvictionGDSF<Key, Value, Cost>::VictimIterator::operator++() -> VictimIterator&
+template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator++() -> VictimIterator&
 {
     ++m_iterator;
     return *this;
 }
 
-template<class Key, class Value, class Cost> auto EvictionGDSF<Key, Value, Cost>::VictimIterator::operator++(int) -> VictimIterator
+template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator++(int) -> VictimIterator
 {
     return (*this)++;
 }
 
-template<class Key, class Value, class Cost> bool EvictionGDSF<Key, Value, Cost>::VictimIterator::operator==(const VictimIterator& other) const
+template<class Key, class KeyHash, class Value, class Cost>
+bool EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator==(const VictimIterator& other) const
 {
     return m_iterator == other.m_iterator;
 }
 
-template<class Key, class Value, class Cost> bool EvictionGDSF<Key, Value, Cost>::VictimIterator::operator!=(const VictimIterator& other) const
+template<class Key, class KeyHash, class Value, class Cost>
+bool EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator!=(const VictimIterator& other) const
 {
     return m_iterator != other.m_iterator;
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::clear()
+template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::clear()
 {
     m_priority_set.clear();
     m_iterator_map.clear();
     m_frequency_sketch.clear();
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::set_cardinality(uint32_t cardinality)
+template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::set_cardinality(uint32_t cardinality)
 {
     m_frequency_sketch = detail::CountingBloomFilter<Key>{cardinality};
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_insert(const Key& key, const CacheItem& item)
+template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_insert(const Key& key, const CacheItem& item)
 {
     m_frequency_sketch.add(key);
 
@@ -62,13 +65,13 @@ template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>
     m_iterator_map[std::ref(key)] = std::move(it);
 }
 
-template<class Key, class Value, class Cost>
-void EvictionGDSF<Key, Value, Cost>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
+template<class Key, class KeyHash, class Value, class Cost>
+void EvictionGDSF<Key, KeyHash, Value, Cost>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
 {
     on_cache_hit(key, new_item);
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_cache_hit(const Key& key, const CacheItem& item)
+template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_cache_hit(const Key& key, const CacheItem& item)
 {
     auto keyref_and_it = m_iterator_map.find(std::ref(key));
     assert(keyref_and_it != m_iterator_map.end());
@@ -80,7 +83,7 @@ template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>
     on_insert(key, item);
 }
 
-template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>::on_evict(const Key& key, const CacheItem& /* item */)
+template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_evict(const Key& key, const CacheItem& /* item */)
 {
     auto keyref_and_it = m_iterator_map.find(std::ref(key));
     assert(keyref_and_it != m_iterator_map.end());
@@ -94,17 +97,18 @@ template<class Key, class Value, class Cost> void EvictionGDSF<Key, Value, Cost>
     assert(m_iterator_map.find(key) == m_iterator_map.end());
 }
 
-template<class Key, class Value, class Cost> auto EvictionGDSF<Key, Value, Cost>::victim_begin() const -> VictimIterator
+template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::victim_begin() const -> VictimIterator
 {
     return VictimIterator{std::move(m_priority_set.begin())};
 }
 
-template<class Key, class Value, class Cost> auto EvictionGDSF<Key, Value, Cost>::victim_end() const -> VictimIterator
+template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::victim_end() const -> VictimIterator
 {
     return VictimIterator{std::move(m_priority_set.end())};
 }
 
-template<class Key, class Value, class Cost> double EvictionGDSF<Key, Value, Cost>::get_h_coefficient(const Key& key, const CacheItem& item) const noexcept
+template<class Key, class KeyHash, class Value, class Cost>
+double EvictionGDSF<Key, KeyHash, Value, Cost>::get_h_coefficient(const Key& key, const CacheItem& item) const noexcept
 {
     return static_cast<double>(m_clock) +
            static_cast<double>(m_frequency_sketch.estimate(key)) * (static_cast<double>(m_measure_cost(key, item)) / static_cast<double>(item.m_total_size));

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -6,6 +6,8 @@
 #include <list>
 #include <map>
 
+#include <absl/container/flat_hash_map.h>
+
 #include "cachemere/item.h"
 
 namespace cachemere::policy {
@@ -15,13 +17,14 @@ namespace cachemere::policy {
 ///          The keys are ordered from most-recently used to least-recently used.
 ///          Only stores references to keys kept alive by the cache.
 /// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename Value> class EvictionLRU
+template<typename Key, typename KeyHash, typename Value> class EvictionLRU
 {
 private:
     using KeyRef    = std::reference_wrapper<const Key>;
     using KeyRefIt  = typename std::list<KeyRef>::iterator;
-    using KeyRefMap = std::map<KeyRef, KeyRefIt, std::less<const Key>>;
+    using KeyRefMap = absl::flat_hash_map<KeyRef, KeyRefIt, KeyHash, std::equal_to<Key>>;
 
 public:
     using CacheItem = cachemere::Item<Value>;

--- a/include/cachemere/policy/eviction_lru.hpp
+++ b/include/cachemere/policy/eviction_lru.hpp
@@ -1,42 +1,43 @@
 namespace cachemere::policy {
 
-template<class Key, class Value> EvictionLRU<Key, Value>::VictimIterator::VictimIterator(const KeyRefReverseIt& iterator) : m_iterator(iterator)
+template<class Key, class KeyHash, class Value>
+EvictionLRU<Key, KeyHash, Value>::VictimIterator::VictimIterator(const KeyRefReverseIt& iterator) : m_iterator(iterator)
 {
 }
 
-template<class Key, class Value> const Key& EvictionLRU<Key, Value>::VictimIterator::operator*() const
+template<class Key, class KeyHash, class Value> const Key& EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator*() const
 {
     return *m_iterator;
 }
 
-template<class Key, class Value> auto EvictionLRU<Key, Value>::VictimIterator::operator++() -> VictimIterator&
+template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator++() -> VictimIterator&
 {
     ++m_iterator;
     return *this;
 }
 
-template<class Key, class Value> auto EvictionLRU<Key, Value>::VictimIterator::operator++(int) -> VictimIterator
+template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator++(int) -> VictimIterator
 {
     return (*this)++;
 }
 
-template<class Key, class Value> bool EvictionLRU<Key, Value>::VictimIterator::operator==(const VictimIterator& other) const
+template<class Key, class KeyHash, class Value> bool EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator==(const VictimIterator& other) const
 {
     return m_iterator == other.m_iterator;
 }
 
-template<class Key, class Value> bool EvictionLRU<Key, Value>::VictimIterator::operator!=(const VictimIterator& other) const
+template<class Key, class KeyHash, class Value> bool EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator!=(const VictimIterator& other) const
 {
     return m_iterator != other.m_iterator;
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::clear()
+template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::clear()
 {
     m_keys.clear();
     m_nodes.clear();
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_insert(const Key& key, const CacheItem& /* item */)
+template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_insert(const Key& key, const CacheItem& /* item */)
 {
     assert(m_nodes.find(std::ref(key)) == m_nodes.end());  // Validate the item is not already in policy.
 
@@ -44,12 +45,13 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_insert(const K
     m_nodes.emplace(std::ref(key), m_keys.begin());
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
+template<class Key, class KeyHash, class Value>
+void EvictionLRU<Key, KeyHash, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
 {
     on_cache_hit(key, new_item);
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
+template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
 {
     auto node_it = m_nodes.find(key);
     if (node_it != m_nodes.end()) {
@@ -63,7 +65,7 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_cache_hit(cons
     }
 }
 
-template<class Key, class Value> void EvictionLRU<Key, Value>::on_evict(const Key& key, const CacheItem& /* item */)
+template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_evict(const Key& key, const CacheItem& /* item */)
 {
     assert(!m_nodes.empty());
     assert(!m_keys.empty());
@@ -78,12 +80,12 @@ template<class Key, class Value> void EvictionLRU<Key, Value>::on_evict(const Ke
     }
 }
 
-template<class Key, class Value> auto EvictionLRU<Key, Value>::victim_begin() const -> VictimIterator
+template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::victim_begin() const -> VictimIterator
 {
     return VictimIterator{m_keys.rbegin()};
 }
 
-template<class Key, class Value> auto EvictionLRU<Key, Value>::victim_end() const -> VictimIterator
+template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::victim_end() const -> VictimIterator
 {
     return VictimIterator{m_keys.rend()};
 }

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -3,6 +3,8 @@
 
 #include <list>
 
+#include <absl/container/flat_hash_map.h>
+
 #include "cachemere/item.h"
 
 namespace cachemere::policy {
@@ -14,12 +16,15 @@ namespace cachemere::policy {
 ///          If the protected segment is full, the item that was least-recently accessed is downgraded to
 ///          the probation segment. This architecture has the effect of reducing cache churn and keeping
 ///          "good" items in cache a bit longer.
-template<typename Key, typename Value> class EvictionSegmentedLRU
+/// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
+/// @tparam Value The type of the values stored in the cache.
+template<typename Key, typename KeyHash, typename Value> class EvictionSegmentedLRU
 {
 private:
     using KeyRef    = std::reference_wrapper<const Key>;
     using KeyRefIt  = typename std::list<KeyRef>::iterator;
-    using KeyRefMap = std::map<KeyRef, KeyRefIt, std::less<const Key>>;
+    using KeyRefMap = absl::flat_hash_map<KeyRef, KeyRefIt, KeyHash, std::equal_to<Key>>;
 
 public:
     using CacheItem = cachemere::Item<Value>;

--- a/include/cachemere/policy/insertion_always.h
+++ b/include/cachemere/policy/insertion_always.h
@@ -6,7 +6,10 @@
 namespace cachemere::policy {
 
 /// @brief Simplest insertion policy. Always accepts insertions.
-template<typename Key, typename Value> class InsertionAlways
+/// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
+/// @tparam Value The type of the values stored in the cache.
+template<typename Key, typename KeyHash, typename Value> class InsertionAlways
 {
 public:
     /// @brief Clears the policy.

--- a/include/cachemere/policy/insertion_always.hpp
+++ b/include/cachemere/policy/insertion_always.hpp
@@ -1,15 +1,16 @@
 namespace cachemere::policy {
 
-template<typename Key, typename Value> void InsertionAlways<Key, Value>::clear()
+template<typename Key, typename KeyHash, typename Value> void InsertionAlways<Key, KeyHash, Value>::clear()
 {
 }
 
-template<typename Key, typename Value> bool InsertionAlways<Key, Value>::should_add(const Key& /* key */)
+template<typename Key, typename KeyHash, typename Value> bool InsertionAlways<Key, KeyHash, Value>::should_add(const Key& /* key */)
 {
     return true;
 }
 
-template<typename Key, typename Value> bool InsertionAlways<Key, Value>::should_replace(const Key& /* key */, const Key& /* candidate */)
+template<typename Key, typename KeyHash, typename Value>
+bool InsertionAlways<Key, KeyHash, Value>::should_replace(const Key& /* key */, const Key& /* candidate */)
 {
     return true;
 }

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -35,7 +35,7 @@ public:
     /// @brief Cache miss event handler.
     /// @details Updates the internal frequency sketches for the given key.
     /// @param key The key that was missed.
-    void on_cache_miss(const Key& key);
+    template<typename KeyType> void on_cache_miss(const KeyType& key);
 
     /// @brief Set the cardinality of the policy.
     /// @details The set cardinality should be a decent approximation of the cardinality
@@ -59,14 +59,14 @@ public:
     bool should_replace(const Key& victim, const Key& candidate);
 
 private:
-    const static uint32_t                     DEFAULT_CACHE_CARDINALITY = 2000;
-    detail::BloomFilter<Key, KeyHash>         m_gatekeeper{DEFAULT_CACHE_CARDINALITY};  // TODO: Investigate using cuckoo filter here instead.
-    detail::CountingBloomFilter<Key, KeyHash> m_frequency_sketch{
-        DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with count-min sketch to get rid of cardinality param.
+    const static uint32_t                DEFAULT_CACHE_CARDINALITY = 2000;
+    detail::BloomFilter<KeyHash>         m_gatekeeper{DEFAULT_CACHE_CARDINALITY};        // TODO: Investigate using cuckoo filter here instead.
+    detail::CountingBloomFilter<KeyHash> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with count-min sketch to get rid of cardinality param.
 
     uint32_t estimate_count_for_key(const Key& key) const;
     void     reset();
-    void     touch_item(const Key& key);
+
+    template<typename KeyType> void touch_item(const KeyType& key);
 };
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -15,7 +15,10 @@ namespace cachemere::policy {
 ///          inserted and/or kept in cache while using a constant amount of memory. The policy uses a combination
 ///          of frequency sketches to keep track of items that have yet to be inserted in the cache, and uses those
 ///          sketches to decide which items should me prioritized.
-template<typename Key, typename Value> class InsertionTinyLFU
+/// @tparam Key The type of the keys used to identify items in the cache.
+/// @tparam KeyHash The type of the hasher used to hash item keys.
+/// @tparam Value The type of the values stored in the cache.
+template<typename Key, typename KeyHash, typename Value> class InsertionTinyLFU
 {
 public:
     using CacheItem = cachemere::Item<Value>;
@@ -56,9 +59,10 @@ public:
     bool should_replace(const Key& victim, const Key& candidate);
 
 private:
-    const static uint32_t            DEFAULT_CACHE_CARDINALITY = 2000;
-    detail::BloomFilter<Key>         m_gatekeeper{DEFAULT_CACHE_CARDINALITY};        // TODO: Investigate using cuckoo filter here instead.
-    detail::CountingBloomFilter<Key> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with count-min sketch to get rid of cardinality param.
+    const static uint32_t                     DEFAULT_CACHE_CARDINALITY = 2000;
+    detail::BloomFilter<Key, KeyHash>         m_gatekeeper{DEFAULT_CACHE_CARDINALITY};  // TODO: Investigate using cuckoo filter here instead.
+    detail::CountingBloomFilter<Key, KeyHash> m_frequency_sketch{
+        DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with count-min sketch to get rid of cardinality param.
 
     uint32_t estimate_count_for_key(const Key& key) const;
     void     reset();

--- a/include/cachemere/policy/insertion_tinylfu.hpp
+++ b/include/cachemere/policy/insertion_tinylfu.hpp
@@ -11,15 +11,15 @@ template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHa
     touch_item(key);
 }
 
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_miss(const Key& key)
+template<class Key, class KeyHash, class Value> template<class KeyType> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_miss(const KeyType& key)
 {
     touch_item(key);
 }
 
 template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::set_cardinality(uint32_t cardinality)
 {
-    m_gatekeeper       = detail::BloomFilter<Key, KeyHash>(cardinality);
-    m_frequency_sketch = detail::CountingBloomFilter<Key, KeyHash>(cardinality);
+    m_gatekeeper       = detail::BloomFilter<KeyHash>(cardinality);
+    m_frequency_sketch = detail::CountingBloomFilter<KeyHash>(cardinality);
 }
 
 template<class Key, class KeyHash, class Value> bool InsertionTinyLFU<Key, KeyHash, Value>::should_add(const Key& key)
@@ -48,7 +48,7 @@ template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHa
     m_frequency_sketch.decay();
 }
 
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::touch_item(const Key& key)
+template<class Key, class KeyHash, class Value> template<class KeyType> void InsertionTinyLFU<Key, KeyHash, Value>::touch_item(const KeyType& key)
 {
     if (m_gatekeeper.maybe_contains(key)) {
         m_frequency_sketch.add(key);

--- a/include/cachemere/policy/insertion_tinylfu.hpp
+++ b/include/cachemere/policy/insertion_tinylfu.hpp
@@ -1,38 +1,38 @@
 namespace cachemere::policy {
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::clear()
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::clear()
 {
     m_gatekeeper.clear();
     m_frequency_sketch.clear();
 }
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
 {
     touch_item(key);
 }
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::on_cache_miss(const Key& key)
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_miss(const Key& key)
 {
     touch_item(key);
 }
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::set_cardinality(uint32_t cardinality)
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::set_cardinality(uint32_t cardinality)
 {
-    m_gatekeeper       = detail::BloomFilter<Key>(cardinality);
-    m_frequency_sketch = detail::CountingBloomFilter<Key>(cardinality);
+    m_gatekeeper       = detail::BloomFilter<Key, KeyHash>(cardinality);
+    m_frequency_sketch = detail::CountingBloomFilter<Key, KeyHash>(cardinality);
 }
 
-template<typename Key, typename Value> bool InsertionTinyLFU<Key, Value>::should_add(const Key& key)
+template<class Key, class KeyHash, class Value> bool InsertionTinyLFU<Key, KeyHash, Value>::should_add(const Key& key)
 {
     return m_gatekeeper.maybe_contains(key);
 }
 
-template<typename Key, typename Value> bool InsertionTinyLFU<Key, Value>::should_replace(const Key& victim, const Key& candidate)
+template<class Key, class KeyHash, class Value> bool InsertionTinyLFU<Key, KeyHash, Value>::should_replace(const Key& victim, const Key& candidate)
 {
     return estimate_count_for_key(candidate) > estimate_count_for_key(victim);
 }
 
-template<typename Key, typename Value> uint32_t InsertionTinyLFU<Key, Value>::estimate_count_for_key(const Key& key) const
+template<class Key, class KeyHash, class Value> uint32_t InsertionTinyLFU<Key, KeyHash, Value>::estimate_count_for_key(const Key& key) const
 {
     uint32_t sketch_estimation = m_frequency_sketch.estimate(key);
     if (m_gatekeeper.maybe_contains(key)) {
@@ -42,13 +42,13 @@ template<typename Key, typename Value> uint32_t InsertionTinyLFU<Key, Value>::es
     return sketch_estimation;
 }
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::reset()
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::reset()
 {
     m_gatekeeper.clear();
     m_frequency_sketch.decay();
 }
 
-template<typename Key, typename Value> void InsertionTinyLFU<Key, Value>::touch_item(const Key& key)
+template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::touch_item(const Key& key)
 {
     if (m_gatekeeper.maybe_contains(key)) {
         m_frequency_sketch.add(key);

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+configure cfg="Debug" dir="build":
+    cmake -B {{dir}} -S . -DUSE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE={{cfg}}
+
+build dir="build":
+    cmake --build {{dir}}
+
+test cfg="Debug" dir="build":
+    @just configure {{cfg}} {{dir}}
+    @just build {{dir}}
+    {{dir}}/tests/cachemere_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(cachemere_tests
         src/memory_cache_tests.cpp
         src/cache_tests.cpp
         src/measurement_tests.cpp
+        src/detail/heterogeneous_lookup_tests.cpp
         src/policy/constraint_count_tests.cpp
         src/policy/constraint_memory_tests.cpp
         src/policy/eviction_lru_tests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,15 +3,20 @@ find_package(GTest REQUIRED)
 add_executable(cachemere_tests)
 
 target_link_libraries(cachemere_tests
-    PRIVATE
+        PRIVATE
         GTest::GTest
         GTest::Main
 
+        absl::container_common
+        absl::flat_hash_map
+        absl::hash
+        absl::node_hash_map
+
         cachemere
-)
+        )
 
 target_sources(cachemere_tests
-    PRIVATE
+        PRIVATE
         src/count_cache_tests.cpp
         src/memory_cache_tests.cpp
         src/cache_tests.cpp
@@ -26,4 +31,4 @@ target_sources(cachemere_tests
         src/policy/detail/bloom_filter_tests.cpp
         src/policy/detail/counting_bloom_filter_tests.cpp
         src/policy/detail/hash_mixer_tests.cpp
-)
+        )

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -15,10 +15,16 @@
 #include "cachemere/cache.h"
 #include "cachemere/measurement.h"
 #include "cachemere/presets.h"
+#include "cachemere/hash.h"
 
 struct Point3D {
     Point3D(uint32_t a, uint32_t b, uint32_t c) : x(a), y(b), z(c)
     {
+    }
+
+    bool operator==(const Point3D& other) const
+    {
+        return x == other.x && y == other.y && z == other.z;
     }
 
     uint32_t x;
@@ -376,4 +382,86 @@ TEST(CacheTest, SingleThreadSwapDoesntThrow)
     // std::lock throws when locking an empty guard, so we need to make sure we don't get in that code path when locking single threaded caches.
     using std::swap;
     swap(cache_a, cache_b);
+}
+
+struct CompositeKey {
+    std::string first_part;
+    std::string second_part;
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeKey& s)
+    {
+        return H::combine(std::move(h), s.first_part, s.second_part);
+    }
+
+    bool operator==(const CompositeKey& other) const
+    {
+        return first_part == other.first_part && second_part == other.second_part;
+    }
+};
+
+struct CompositeKeyView {
+    std::string_view first_part;
+    std::string_view second_part;
+
+    bool operator==(const CompositeKeyView& other) const
+    {
+        return first_part == other.first_part && second_part == other.second_part;
+    }
+
+    bool operator==(const CompositeKey& other) const
+    {
+        return first_part == other.first_part && second_part == other.second_part;
+    }
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeKeyView& s)
+    {
+        return H::combine(std::move(h), s.first_part, s.second_part);
+    }
+};
+
+TEST(CacheTest, FindHeterogeneousLookup)
+{
+    // Can hash either a `CompositeKey` with `absl::Hash` or a `CompositeKeyView` with absl::Hash.
+    using Hasher = MultiHash<CompositeKey, absl::Hash<CompositeKey>, CompositeKeyView, absl::Hash<CompositeKeyView>>;
+
+    using TestCache = presets::memory::TinyLFUCache<CompositeKey, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<CompositeKey>, Hasher>;
+
+    TestCache cache{100 * sizeof(Point3D)};
+
+    CompositeKey     key{"asdf", "hjkl"};
+    CompositeKeyView key_view{"asdf", "hjkl"};
+
+    Point3D value{1, 1, 1};
+
+    // Since the insertion policy is TinyLFU, the cache needs to have seen the key at least once before allowing its insertion.
+    // We'll perform a manual find using the key_view beforehand to simulate that cache miss.
+    cache.find(key_view);
+    cache.insert(key, value);
+
+    auto actual_value = cache.find(key_view);
+
+    EXPECT_TRUE(actual_value.has_value());
+    EXPECT_EQ(*actual_value, value);
+}
+
+TEST(CacheTest, ContainsHeterogeneousLookup)
+{
+    using Hasher    = MultiHash<CompositeKey, absl::Hash<CompositeKey>, CompositeKeyView, absl::Hash<CompositeKeyView>>;
+    using TestCache = presets::memory::TinyLFUCache<CompositeKey, Point3D, measurement::SizeOf<Point3D>, measurement::SizeOf<CompositeKey>, Hasher>;
+
+    TestCache cache{100 * sizeof(Point3D)};
+
+    CompositeKey     key{"asdf", "hjkl"};
+    CompositeKeyView key_view{"asdf", "hjkl"};
+
+    Point3D value{1, 1, 1};
+
+    EXPECT_FALSE(cache.contains(key_view));
+
+    // Since the insertion policy is TinyLFU, the cache needs to have seen the key at least once before allowing its insertion.
+    // We'll perform a manual find using the key_view beforehand to simulate that cache miss.
+    cache.find(key_view);
+    cache.insert(key, value);
+
+    EXPECT_TRUE(cache.contains(key_view));
 }

--- a/tests/src/detail/heterogeneous_lookup_tests.cpp
+++ b/tests/src/detail/heterogeneous_lookup_tests.cpp
@@ -1,0 +1,86 @@
+#include <absl/hash/hash.h>
+#include <gtest/gtest.h>
+
+#include "cachemere/hash.h"
+#include "cachemere/detail/transparent_eq.h"
+
+using namespace cachemere::detail;
+
+TEST(TransparentEq, CanEqualSelf)
+{
+    using EqT = TransparentEq<std::string>;
+
+    EqT         eq;
+    std::string val{"asdf"};
+
+    EXPECT_TRUE(eq(val, val));
+    EXPECT_TRUE(eq(val, std::string_view("asdf")));
+    EXPECT_FALSE(eq(val, std::string_view("bing bong")));
+    EXPECT_TRUE(eq(val, val.c_str()));
+}
+
+TEST(MultiHash, CanHashSingleType)
+{
+    using NonRecursiveHasher = cachemere::MultiHash<std::string, absl::Hash<std::string>>;
+
+    NonRecursiveHasher hasher;
+
+    hasher("asdf");
+}
+
+TEST(MultiHash, CanHashMultipleTypes)
+{
+    using RecursiveHasher = cachemere::MultiHash<std::string, absl::Hash<std::string>, uint32_t, absl::Hash<uint32_t>>;
+
+    RecursiveHasher hasher;
+
+    hasher("asdf");
+    hasher(static_cast<uint32_t>(42));
+}
+
+struct CompositeType {
+    std::string a;
+    std::string b;
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeType& s)
+    {
+        return H::combine(std::move(h), s.a, s.b);
+    }
+
+    bool operator==(const CompositeType& other) const
+    {
+        return a == other.a && b == other.b;
+    }
+};
+
+struct CompositeView {
+    std::string_view a;
+    std::string_view b;
+
+    bool operator==(const CompositeView& other) const
+    {
+        return a == other.a && b == other.b;
+    }
+
+    bool operator==(const CompositeType& other) const
+    {
+        return a == other.a && b == other.b;
+    }
+
+    template<typename H> friend H AbslHashValue(H h, const CompositeView& s)
+    {
+        return H::combine(std::move(h), s.a, s.b);
+    }
+};
+
+TEST(MultiHash, CanHashComplexTypes)
+{
+    using MultiHasher = cachemere::MultiHash<CompositeType, absl::Hash<CompositeType>, CompositeView, absl::Hash<CompositeView>>;
+
+    MultiHasher hasher;
+
+    auto hash_a = hasher(CompositeType{"a", "b"});
+    auto hash_b = hasher(CompositeView{std::string_view{"a"}, std::string_view{"b"}});
+
+    EXPECT_EQ(hash_a, hash_b);
+}

--- a/tests/src/policy/constraint_count_tests.cpp
+++ b/tests/src/policy/constraint_count_tests.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/item.h"
 #include "cachemere/policy/constraint_count.h"
 
 using namespace cachemere;
 
 using TestItem       = Item<uint32_t>;
-using TestConstraint = policy::ConstraintCount<std::string, uint32_t>;
+using TestConstraint = policy::ConstraintCount<std::string, absl::Hash<std::string>, uint32_t>;
 
 TEST(ConstraintCount, InitializesMaxCountAndCount)
 {

--- a/tests/src/policy/constraint_memory_tests.cpp
+++ b/tests/src/policy/constraint_memory_tests.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/item.h"
 #include "cachemere/policy/constraint_memory.h"
 
 using namespace cachemere;
 
 using TestItem       = Item<uint32_t>;
-using TestConstraint = policy::ConstraintMemory<std::string, uint32_t>;
+using TestConstraint = policy::ConstraintMemory<std::string, absl::Hash<std::string>, uint32_t>;
 
 TEST(ConstraintMemory, InitializesMaxMemoryAndMemory)
 {

--- a/tests/src/policy/detail/bloom_filter_tests.cpp
+++ b/tests/src/policy/detail/bloom_filter_tests.cpp
@@ -1,12 +1,14 @@
+#include <absl/hash/hash.h>
 #include <gtest/gtest.h>
 
 #include "cachemere/policy/detail/bloom_filter.h"
+#include "cachemere/hash.h"
 
 using namespace cachemere::policy::detail;
 
 TEST(BloomFilter, BasicAdd)
 {
-    BloomFilter<std::string> filter{5};
+    BloomFilter<absl::Hash<std::string>> filter{5};
     filter.add("hello world");
     ASSERT_TRUE(filter.maybe_contains("hello world"));
 }
@@ -15,7 +17,7 @@ TEST(BloomFilter, FalsePositiveRate)
 {
     const uint32_t cardinality = 100;
 
-    BloomFilter<uint32_t> filter{cardinality};
+    BloomFilter<absl::Hash<uint32_t>> filter{cardinality};
 
     for (uint32_t i = 0; i < cardinality; ++i) {
         filter.add(i);
@@ -39,8 +41,8 @@ TEST(BloomFilter, FalsePositiveRate)
 
 TEST(BloomFilter, FilterSaturation)
 {
-    const uint32_t        cardinality = 5;
-    BloomFilter<uint32_t> filter{cardinality};
+    const uint32_t                    cardinality = 5;
+    BloomFilter<absl::Hash<uint32_t>> filter{cardinality};
 
     // Completely saturate the filter. After this, every filter bit should be set to `1`.
     for (uint32_t i = 0; i < cardinality * 100; ++i) {
@@ -57,7 +59,7 @@ TEST(BloomFilter, FilterSaturation)
 
 TEST(BloomFilter, Clear)
 {
-    BloomFilter<uint32_t> filter{5};
+    BloomFilter<absl::Hash<uint32_t>> filter{5};
 
     filter.add(42);
     EXPECT_TRUE(filter.maybe_contains(42));
@@ -68,4 +70,20 @@ TEST(BloomFilter, Clear)
     EXPECT_FALSE(filter.maybe_contains(42));
     EXPECT_GT(filter.memory_used(), static_cast<size_t>(0));
     EXPECT_LT(abs(static_cast<int32_t>(size_pre_clear) - static_cast<int32_t>(filter.memory_used())), 500);
+}
+
+TEST(BloomFilter, HeterogeneousLookupString)
+{
+    using Hash = cachemere::MultiHash<std::string, absl::Hash<std::string>, std::string_view, absl::Hash<std::string_view>>;
+
+    BloomFilter<Hash> filter{5};
+
+    const std::string      key_str        = "asdf";
+    const std::string_view key_view       = "asdf";
+    const std::string_view unrelated_view = "hjkl";
+
+    filter.add(key_str);
+
+    EXPECT_TRUE(filter.maybe_contains(key_view));
+    EXPECT_FALSE(filter.maybe_contains(unrelated_view));
 }

--- a/tests/src/policy/detail/counting_bloom_filter_tests.cpp
+++ b/tests/src/policy/detail/counting_bloom_filter_tests.cpp
@@ -1,11 +1,13 @@
+#include <absl/hash/hash.h>
 #include <gtest/gtest.h>
 
 #include "cachemere/policy/detail/counting_bloom_filter.h"
 
 using namespace cachemere::policy::detail;
 
-TEST(CountingBloomFilter, BasicCount) {
-    CountingBloomFilter<std::string> filter{5};
+TEST(CountingBloomFilter, BasicCount)
+{
+    CountingBloomFilter<absl::Hash<std::string>> filter{5};
     EXPECT_EQ(0, filter.estimate("hello world"));
 
     filter.add("hello world");
@@ -15,8 +17,9 @@ TEST(CountingBloomFilter, BasicCount) {
     EXPECT_EQ(2, filter.estimate("hello world"));
 }
 
-TEST(CountingBloomFilter, FilterSaturation) {
-    CountingBloomFilter<uint32_t> filter{5};
+TEST(CountingBloomFilter, FilterSaturation)
+{
+    CountingBloomFilter<absl::Hash<uint32_t>> filter{5};
 
     for (auto i = 0; i < 1000; ++i) {
         filter.add(i);
@@ -29,8 +32,9 @@ TEST(CountingBloomFilter, FilterSaturation) {
     }
 }
 
-TEST(CountingBloomFilter, Clear) {
-    CountingBloomFilter<uint32_t> filter{5};
+TEST(CountingBloomFilter, Clear)
+{
+    CountingBloomFilter<absl::Hash<uint32_t>> filter{5};
     filter.add(42);
 
     auto sizePreClear = filter.memory_used();

--- a/tests/src/policy/detail/hash_mixer_tests.cpp
+++ b/tests/src/policy/detail/hash_mixer_tests.cpp
@@ -3,11 +3,13 @@
 #include <cstring>
 #include <functional>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/policy/detail/hash_mixer.h"
 
 using namespace cachemere::policy::detail;
 
-using TestMixer = HashMixer<std::string, std::hash<std::string>>;
+using TestMixer = HashMixer<std::string, absl::Hash<std::string>>;
 
 TEST(HashMixer, StaysWithinRange)
 {

--- a/tests/src/policy/eviction_gdsf_tests.cpp
+++ b/tests/src/policy/eviction_gdsf_tests.cpp
@@ -4,6 +4,8 @@
 #include <set>
 #include <string>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/policy/eviction_gdsf.h"
 
 using namespace cachemere;
@@ -25,8 +27,8 @@ struct QuadraticSizeCost {
     }
 };
 
-using ConstantCostGDSF  = policy::EvictionGDSF<std::string, int32_t, ConstantCost>;
-using QuadraticCostGDSF = policy::EvictionGDSF<std::string, int32_t, QuadraticSizeCost>;
+using ConstantCostGDSF  = policy::EvictionGDSF<std::string, absl::Hash<std::string>, int32_t, ConstantCost>;
+using QuadraticCostGDSF = policy::EvictionGDSF<std::string, absl::Hash<std::string>, int32_t, QuadraticSizeCost>;
 
 template<typename Policy> void insert_item(std::string key, int32_t value, Policy& policy, ItemMap& item_map)
 {

--- a/tests/src/policy/eviction_lru_tests.cpp
+++ b/tests/src/policy/eviction_lru_tests.cpp
@@ -5,12 +5,14 @@
 #include <tuple>
 #include <vector>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/item.h"
 #include "cachemere/policy/eviction_lru.h"
 
 using namespace cachemere;
 
-using TestLRU  = policy::EvictionLRU<std::string, int32_t>;
+using TestLRU  = policy::EvictionLRU<std::string, absl::Hash<std::string>, int32_t>;
 using TestItem = Item<int32_t>;
 using ItemMap  = std::map<std::string, TestItem>;
 
@@ -22,7 +24,7 @@ void insert_item(std::string key, int32_t value, TestLRU& policy, ItemMap& item_
     policy.on_insert(key_and_item->first, key_and_item->second);
 }
 
-void expect_victims(const TestLRU& policy, std::vector<std::string> expected_victims)
+void expect_victims(const TestLRU& policy, const std::vector<std::string>& expected_victims)
 {
     std::vector<std::string> victims;
     for (auto it = policy.victim_begin(); it != policy.victim_end(); ++it) {

--- a/tests/src/policy/eviction_segmented_lru_tests.cpp
+++ b/tests/src/policy/eviction_segmented_lru_tests.cpp
@@ -3,12 +3,14 @@
 #include <string>
 #include <map>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/item.h"
 #include "cachemere/policy/eviction_segmented_lru.h"
 
 using namespace cachemere;
 
-using TestSLRU = policy::EvictionSegmentedLRU<std::string, int32_t>;
+using TestSLRU = policy::EvictionSegmentedLRU<std::string, absl::Hash<std::string>, int32_t>;
 using TestItem = Item<int32_t>;
 using ItemMap  = std::map<std::string, TestItem>;
 

--- a/tests/src/policy/insertion_always_tests.cpp
+++ b/tests/src/policy/insertion_always_tests.cpp
@@ -1,3 +1,4 @@
+#include <absl/hash/hash.h>
 #include <gtest/gtest.h>
 
 #include "cachemere/policy/insertion_always.h"
@@ -6,7 +7,7 @@ using namespace cachemere::policy;
 
 TEST(InsertionAlways, AlwaysInserts)
 {
-    InsertionAlways<uint32_t, uint32_t> policy;
+    InsertionAlways<uint32_t, absl::Hash<uint32_t>, uint32_t> policy;
 
     for (auto i = 0; i < 100; ++i) {
         EXPECT_TRUE(policy.should_add(i));
@@ -15,7 +16,7 @@ TEST(InsertionAlways, AlwaysInserts)
 
 TEST(InsertionAlways, AlwaysReplaces)
 {
-    InsertionAlways<uint32_t, uint32_t> policy;
+    InsertionAlways<uint32_t, absl::Hash<uint32_t>, uint32_t> policy;
 
     for (auto i = 1; i < 100; ++i) {
         EXPECT_TRUE(policy.should_replace(i - 1, i));

--- a/tests/src/policy/insertion_tinylfu_tests.cpp
+++ b/tests/src/policy/insertion_tinylfu_tests.cpp
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <absl/hash/hash.h>
+
 #include "cachemere/policy/insertion_tinylfu.h"
 
 using namespace cachemere;
 
-using TestPolicy = policy::InsertionTinyLFU<uint32_t, uint32_t>;
+using TestPolicy = policy::InsertionTinyLFU<uint32_t, absl::Hash<uint32_t>, uint32_t>;
 
 TEST(InsertionTinyLFU, ShouldAddAlwaysTrue)
 {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,13 @@
   "version-semver": "0.2.6",
   "dependencies": [
     {
+      "name": "abseil",
+      "version>=": "20220623.1",
+      "features": [
+        "cxx17"
+      ]
+    },
+    {
       "name": "vcpkg-cmake",
       "version>=": "2021-02-28",
       "host": true,


### PR DESCRIPTION
## 1. Replacement of containers with [abseil](https://abseil.io/) containers
### Motivation
- Abseil containers generally perform better than standard containers
- Abseil containers support [heterogeneous lookup](https://abseil.io/tips/144), which will in turn allow us to support it in the cache 
  - (See https://github.com/coveooss/cachemere/pull/31)
### Overview
- Adds a dependency on abseil
- The main container of the cache changes from an `std::unordered_map` to `absl::node_hash_map`. `absl::flat_hash_map` would have been prefereable, but is not currently possible since cachemere's design requires pointer stability for the main container (since policies borrow keys & values from the main container)
- Associative containers used in policies can use `absl::flat_hash_map` (resulting in much faster lookups and less memory usage) since they don't need pointer stability.

## 2. Allow customization of hasher object used by the cache
### Motivation
- Implementations of `std::hash` (the current default) often are [horrendous hashing functions](https://martin.ankerl.com/2022/08/27/hashmap-bench-01/#stdhash-), especially for integral types.
- Implementations of `std::hash` cause gigantic performance problems with numeric keys and abseil containers.
- Hasher customization is a pre-requisite of heterogeneous lookup.
### Overview
- Added a new `KeyHash` template parameter to `cachemere::Cache` (and related cache presets)
- `KeyHash` has a default value of `absl::Hash<Key>`

-----
This is a large pull request, but all of the changes are pretty mechanical (the overwhelming majority of line changes are either replacing `std::hash` by `absl::Hash` _or_ adding the new `KeyHash` template parameter in _all_ cache and policy method signatures).