### PR TITLE
[IDX-7032] Move to ticket-based eviction system when cache is full

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -221,11 +221,13 @@ private:
     mutable MeanAccumulator m_hit_rate_acc;
     mutable MeanAccumulator m_byte_hit_rate_acc;
 
-    bool check_insert(const Key& candidate_key, const CacheItem& item);
-    bool check_replace(const Key& candidate_key, const CacheItem& old_item, const CacheItem& new_item);
+    template<class ConstraintTicket> bool collect_evictions(const Key& candidate_key, ConstraintTicket& ticket);
+    bool                                  check_insert(const Key& candidate_key, const CacheItem& item);
+    bool                                  check_replace(const Key& candidate_key, const CacheItem& old_item, const CacheItem& new_item);
 
     void insert_or_update(Key&& key, CacheItem&& value);
     void remove(DataMapIt it);
+    void remove_popped_victim(DataMapIt it);
 
     void                            on_insert(const Key& key, const CacheItem& item) const;
     void                            on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item) const;
@@ -563,18 +565,14 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::update_constraint(Args... args)
     LockGuard guard(lock());
     m_constraint_policy->update(std::forward<Args>(args)...);
 
-    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !m_constraint_policy->is_satisfied(); };
+    while (!m_constraint_policy->is_satisfied()) {
+        auto eviction_ticket = m_eviction_policy->pop_victim();
+        auto key_and_item    = m_data.find(eviction_ticket.key());
 
-    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); victim_it = m_eviction_policy->victim_begin()) {
-        const K& key_to_evict = *victim_it;
-        auto     key_and_item = m_data.find(key_to_evict);
+        // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
+        assert(key_and_item != m_data.end());
 
-        if (key_and_item != m_data.end()) {
-            remove(key_and_item);
-        } else {
-            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
-            assert(false);
-        }
+        remove_popped_victim(key_and_item);
     }
 
     assert(m_constraint_policy->is_satisfied());
@@ -803,7 +801,7 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::import(Coll& collection)
         const auto value_size = static_cast<size_t>(m_measure_value(value));
         CacheItem  item{key_size, std::move(value), value_size};
 
-        if (!m_constraint_policy->can_add(key, item)) {
+        if (!m_constraint_policy->prepare_insert(key, item).is_satisfied()) {
             return;
         }
 
@@ -820,51 +818,61 @@ template<class K,
          class SK,
          class KH,
          bool TS>
+template<class ConstraintTicket>
+bool Cache<K, V, I, E, C, SV, SK, KH, TS>::collect_evictions(const K& candidate_key, ConstraintTicket& ticket)
+{
+    std::vector<std::pair<typename MyEvictionPolicy::Ticket, DataMapIt>> keys_to_evict;
+
+    while (!ticket.is_satisfied()) {
+        auto eviction_ticket = m_eviction_policy->pop_victim();
+        auto key_and_item    = m_data.find(eviction_ticket.key());
+
+        // If this trips, the eviction policy recommended the eviction of a key not in cache: the eviction policy and the
+        // cache are out of sync.
+        assert(key_and_item != m_data.end());
+
+        if (!m_insertion_policy->should_replace(key_and_item->first, candidate_key)) {
+            m_eviction_policy->rollback(std::move(eviction_ticket));
+            for (auto it = keys_to_evict.rbegin(); it != keys_to_evict.rend(); ++it) {
+                m_eviction_policy->rollback(std::move(it->first));
+            }
+            return false;
+        }
+
+        ticket.register_eviction(key_and_item->first, key_and_item->second);
+        keys_to_evict.emplace_back(std::move(eviction_ticket), key_and_item);
+    }
+
+    for (auto& [_, key_and_item] : keys_to_evict) {
+        remove_popped_victim(key_and_item);
+    }
+
+    return true;
+}
+
+template<class K,
+         class V,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
 bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_insert(const K& key, const CacheItem& item)
 {
-    if (m_constraint_policy->can_add(key, item)) {
+    auto insertion_ticket = m_constraint_policy->prepare_insert(key, item);
+
+    if (insertion_ticket.is_satisfied()) {
+        // The constraint is already satisfied, so we just check the insertion policy.
         return m_insertion_policy->should_add(key);
     }
 
-    // We need to perform some evictions to try and make some room.
-    // Since the insertion process can fail at anytime before we know how many keys to evict (e.g. if should_replace was to return false) however,
-    // we can't directly evict items as we go. To fix this, we copy the constraint policy to see how many keys we'd have to evict. If we manage to
-    // satisfy the constraint copy, we evict the keys we picked and proceed with the insertion.
-    auto                   constraint_copy = std::make_unique<MyConstraintPolicy>(*m_constraint_policy);
-    std::vector<DataMapIt> keys_to_evict;
-
-    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !constraint_copy->can_add(key, item); };
-
-    // As long as the constraint isn't satisfied, we keep evicting keys.
-    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); ++victim_it) {
-        const K& key_to_evict = *victim_it;
-        auto     key_and_item = m_data.find(key_to_evict);
-
-        if (key_and_item != m_data.end()) {
-            if (!m_insertion_policy->should_replace(key_to_evict, key)) {
-                // This key to evict is considered "better" to have in cache than the item to be inserted.
-                // In this case, we abort the insertion.
-                return false;
-            }
-
-            constraint_copy->on_evict(key_and_item->first, key_and_item->second);
-            keys_to_evict.push_back(key_and_item);
-        } else {
-            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the
-            // cache are out of sync.
-            assert(false);
-        }
+    if (!insertion_ticket.is_satisfiable()) {
+        return false;  // item can't be inserted even if we evict everything.
     }
 
-    if (constraint_copy->can_add(key, item)) {
-        // The constraint is happy with that, so we actually evict the collected keys.
-        for (auto key_and_item : keys_to_evict) {
-            remove(key_and_item);
-        }
-        return true;
-    }
-
-    return false;
+    return collect_evictions(key, insertion_ticket);
 }
 
 template<class K,
@@ -878,61 +886,17 @@ template<class K,
          bool TS>
 bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item)
 {
-    if (m_constraint_policy->can_replace(key, old_item, new_item)) {
+    auto replacement_ticket = m_constraint_policy->prepare_replace(key, old_item, new_item);
+
+    if (replacement_ticket.is_satisfied()) {
         return true;
     }
 
-    // The logic here is very similar to check_insert but with an important modification.
-    // Since in this code path we're updating an existing key instead of adding a new one, we need to handle the case
-    // where the eviction policy recommends the eviction of the key we're trying to insert. If this happens and the constraint
-    // is still not satisfied afterwards, we need to treat all subsequent constraint checks as if we were inserting instead of updating our key
-    // (because the original was evicted).
-    auto constraint_copy      = std::make_unique<MyConstraintPolicy>(*m_constraint_policy);
-    bool evicted_original_key = false;
-
-    auto can_replace = [&]() {
-        if (evicted_original_key) {
-            return constraint_copy->can_add(key, new_item);
-        } else {
-            return constraint_copy->can_replace(key, old_item, new_item);
-        }
-    };
-
-    auto should_evict_another = [&](auto victim_it) { return victim_it != m_eviction_policy->victim_end() && !can_replace(); };
-
-    // Evict until the constraint copy is happy.
-    std::vector<DataMapIt> keys_to_evict;
-
-    for (auto victim_it = m_eviction_policy->victim_begin(); should_evict_another(victim_it); ++victim_it) {
-        const K& key_to_evict = *victim_it;
-        auto     key_and_item = m_data.find(key_to_evict);
-
-        if (key_and_item != m_data.end()) {
-            if (!m_insertion_policy->should_replace(key_to_evict, key)) {
-                return false;
-            }
-
-            if (!evicted_original_key) {
-                evicted_original_key = key_and_item->first == key;
-            }
-
-            constraint_copy->on_evict(key_and_item->first, key_and_item->second);
-            keys_to_evict.push_back(key_and_item);
-        } else {
-            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the
-            // cache are out of sync.
-            assert(false);
-        }
+    if (!replacement_ticket.is_satisfiable()) {
+        return false;
     }
 
-    if (can_replace()) {
-        for (auto key_and_item : keys_to_evict) {
-            remove(key_and_item);
-        }
-        return true;
-    }
-
-    return false;
+    return collect_evictions(key, replacement_ticket);
 }
 
 template<class K,
@@ -971,6 +935,28 @@ template<class K,
 void Cache<K, V, I, E, C, SV, SK, KH, TS>::remove(DataMapIt it)
 {
     on_evict(it->first, it->second);
+    m_data.erase(it);
+}
+
+template<class K,
+         class V,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+void Cache<K, V, I, E, C, SV, SK, KH, TS>::remove_popped_victim(DataMapIt it)
+{
+    boost::hana::if_(
+        detail::traits::event::has_on_evict<K, KH, V, I>,
+        [&](auto& x) { return x.on_evict(it->first, it->second); },
+        [](auto&) {})(*m_insertion_policy);
+    boost::hana::if_(
+        detail::traits::event::has_on_evict<K, KH, V, C>,
+        [&](auto& x) { return x.on_evict(it->first, it->second); },
+        [](auto&) {})(*m_constraint_policy);
     m_data.erase(it);
 }
 

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -48,12 +48,9 @@ namespace cachemere {
 /// @tparam ThreadSafe Whether to enable locking. When true, all cache operations will be protected by a lock. `true` by default.
 template<typename Key,
          typename Value,
-         template<class, class, class>
-         class InsertionPolicy,
-         template<class, class, class>
-         class EvictionPolicy,
-         template<class, class, class>
-         class ConstraintPolicy,
+         template<class, class, class> class InsertionPolicy,
+         template<class, class, class> class EvictionPolicy,
+         template<class, class, class> class ConstraintPolicy,
          typename MeasureValue = measurement::Size<Value>,
          typename MeasureKey   = measurement::Size<Key>,
          typename KeyHash      = absl::Hash<Key>,
@@ -239,12 +236,9 @@ private:
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -253,12 +247,9 @@ void swap(Cache<K, V, I, E, C, SV, SK, KH, TS>& lhs, Cache<K, V, I, E, C, SV, SK
 
 template<typename Key,
          typename Value,
-         template<class, class, class>
-         class InsertionPolicy,
-         template<class, class, class>
-         class EvictionPolicy,
-         template<class, class, class>
-         class ConstraintPolicy,
+         template<class, class, class> class InsertionPolicy,
+         template<class, class, class> class EvictionPolicy,
+         template<class, class, class> class ConstraintPolicy,
          typename MeasureValue,
          typename MeasureKey,
          typename KeyHash,
@@ -277,12 +268,9 @@ Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValu
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -303,12 +291,9 @@ Cache<K, V, I, E, C, SV, SK, KH, TS>::Cache(Coll& collection, std::tuple<Args...
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -322,12 +307,9 @@ inline bool Cache<K, V, I, E, C, SV, SK, KH, TS>::contains(const KeyView& key) c
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -349,12 +331,9 @@ std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, TS>::find(const KeyView& key) 
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -386,12 +365,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::collect_into(Container& container) co
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -427,12 +403,9 @@ bool Cache<K, V, I, E, C, SV, SK, KH, TS>::insert(K key, V value)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -451,12 +424,9 @@ bool Cache<K, V, I, E, C, SV, SK, KH, TS>::remove(const K& key)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -477,12 +447,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::clear()
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -505,12 +472,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::retain(P predicate_fn)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -526,12 +490,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::for_each(F unary_function)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -574,12 +535,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::swap(CacheType& other) noexcept
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -592,12 +550,9 @@ inline size_t Cache<K, V, I, E, C, SV, SK, KH, TS>::number_of_items() const
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -627,12 +582,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::update_constraint(Args... args)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -644,12 +596,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::insertion_policy() -> MyInsert
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -661,12 +610,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::insertion_policy() const -> co
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -678,12 +624,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::eviction_policy() -> MyEvictio
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -695,12 +638,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::eviction_policy() const -> con
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -712,12 +652,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::constraint_policy() -> MyConst
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -729,12 +666,9 @@ inline auto Cache<K, V, I, E, C, SV, SK, KH, TS>::constraint_policy() const -> c
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -746,12 +680,9 @@ inline double Cache<K, V, I, E, C, SV, SK, KH, TS>::hit_rate() const
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -763,12 +694,9 @@ inline double Cache<K, V, I, E, C, SV, SK, KH, TS>::byte_hit_rate() const
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -780,12 +708,9 @@ inline uint32_t Cache<K, V, I, E, C, SV, SK, KH, TS>::statistics_window_size() c
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -800,12 +725,9 @@ inline void Cache<K, V, I, E, C, SV, SK, KH, TS>::statistics_window_size(uint32_
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -823,12 +745,9 @@ auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock() const -> LockGuard
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -846,12 +765,9 @@ auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock([[maybe_unused]] std::defer_lock
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -870,12 +786,9 @@ auto Cache<K, V, I, E, C, SV, SK, KH, TS>::lock_pair(CacheType& other) const -> 
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -900,12 +813,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::import(Coll& collection)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -959,12 +869,9 @@ bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_insert(const K& key, const Cach
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1030,12 +937,9 @@ bool Cache<K, V, I, E, C, SV, SK, KH, TS>::check_replace(const K& key, const Cac
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1057,12 +961,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::insert_or_update(K&& key, CacheItem&&
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1075,12 +976,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::remove(DataMapIt it)
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1088,30 +986,18 @@ template<class K,
 void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_insert(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
-    boost::hana::if_(
-        detail::traits::event::has_on_insert<K, KH, V, I>,
-        [&](auto& x) { return x.on_insert(key, item); },
-        [](auto&) {})(*m_insertion_policy);
+    boost::hana::if_(detail::traits::event::has_on_insert<K, KH, V, I>, [&](auto& x) { return x.on_insert(key, item); }, [](auto&) {})(*m_insertion_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_insert<K, KH, V, E>,
-        [&](auto& x) { return x.on_insert(key, item); },
-        [](auto&) {})(*m_eviction_policy);
+    boost::hana::if_(detail::traits::event::has_on_insert<K, KH, V, E>, [&](auto& x) { return x.on_insert(key, item); }, [](auto&) {})(*m_eviction_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_insert<K, KH, V, C>,
-        [&](auto& x) { return x.on_insert(key, item); },
-        [](auto&) {})(*m_constraint_policy);
+    boost::hana::if_(detail::traits::event::has_on_insert<K, KH, V, C>, [&](auto& x) { return x.on_insert(key, item); }, [](auto&) {})(*m_constraint_policy);
 }
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1137,12 +1023,9 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_update(const K& key, const CacheIt
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1159,25 +1042,19 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_hit(const K& key, const Cach
         [&](auto& x) { return x.on_cache_hit(key, item); },
         [](auto&) {})(*m_insertion_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_cachehit<K, KH, V, E>,
-        [&](auto& x) { return x.on_cache_hit(key, item); },
-        [](auto&) {})(*m_eviction_policy);
+    boost::hana::if_(detail::traits::event::has_on_cachehit<K, KH, V, E>, [&](auto& x) { return x.on_cache_hit(key, item); }, [](auto&) {})(*m_eviction_policy);
 
     boost::hana::if_(
-        detail::traits::event::has_on_cachehit<K, KH, V, E>,
+        detail::traits::event::has_on_cachehit<K, KH, V, C>,
         [&](auto& x) { return x.on_cache_hit(key, item); },
-        [](auto&) {})(*m_eviction_policy);
+        [](auto&) {})(*m_constraint_policy);
 }
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1190,30 +1067,18 @@ void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_cache_miss(const KeyView& key) con
     m_byte_hit_rate_acc(0);
 
     // Call event handler iif the method is defined in the policy.
-    boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, KH, V, I>,
-        [&](auto& x) { return x.on_cache_miss(key); },
-        [](auto&) {})(*m_insertion_policy);
+    boost::hana::if_(detail::traits::event::has_on_cachemiss<K, KH, V, I>, [&](auto& x) { return x.on_cache_miss(key); }, [](auto&) {})(*m_insertion_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, KH, V, E>,
-        [&](auto& x) { return x.on_cache_miss(key); },
-        [](auto&) {})(*m_eviction_policy);
+    boost::hana::if_(detail::traits::event::has_on_cachemiss<K, KH, V, E>, [&](auto& x) { return x.on_cache_miss(key); }, [](auto&) {})(*m_eviction_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_cachemiss<K, KH, V, C>,
-        [&](auto& x) { return x.on_cache_miss(key); },
-        [](auto&) {})(*m_constraint_policy);
+    boost::hana::if_(detail::traits::event::has_on_cachemiss<K, KH, V, C>, [&](auto& x) { return x.on_cache_miss(key); }, [](auto&) {})(*m_constraint_policy);
 }
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,
@@ -1221,30 +1086,18 @@ template<class K,
 void Cache<K, V, I, E, C, SV, SK, KH, TS>::on_evict(const K& key, const CacheItem& item) const
 {
     // Call event handler iif the method is defined in the policy.
-    boost::hana::if_(
-        detail::traits::event::has_on_evict<K, KH, V, I>,
-        [&](auto& x) { return x.on_evict(key, item); },
-        [](auto&) {})(*m_insertion_policy);
+    boost::hana::if_(detail::traits::event::has_on_evict<K, KH, V, I>, [&](auto& x) { return x.on_evict(key, item); }, [](auto&) {})(*m_insertion_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_evict<K, KH, V, E>,
-        [&](auto& x) { return x.on_evict(key, item); },
-        [](auto&) {})(*m_eviction_policy);
+    boost::hana::if_(detail::traits::event::has_on_evict<K, KH, V, E>, [&](auto& x) { return x.on_evict(key, item); }, [](auto&) {})(*m_eviction_policy);
 
-    boost::hana::if_(
-        detail::traits::event::has_on_evict<K, KH, V, C>,
-        [&](auto& x) { return x.on_evict(key, item); },
-        [](auto&) {})(*m_constraint_policy);
+    boost::hana::if_(detail::traits::event::has_on_evict<K, KH, V, C>, [&](auto& x) { return x.on_evict(key, item); }, [](auto&) {})(*m_constraint_policy);
 }
 
 template<class K,
          class V,
-         template<class, class, class>
-         class I,
-         template<class, class, class>
-         class E,
-         template<class, class, class>
-         class C,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
          class SV,
          class SK,
          class KH,

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -72,13 +72,6 @@ public:
     [[nodiscard]] InsertionTicket   prepare_insert(const Key& key, const CacheItem& item);
     [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
-    /// @brief Determines whether an insertion candidate can be added into the cache.
-    /// @details That is, whether the constraint would still be satisfied after inserting the candidate.
-    /// @param key The key of the insertion candidate.
-    /// @param item The candidate item.
-    /// @return Whether the item can be added in cache.
-    [[nodiscard]] bool can_add(const Key& key, const CacheItem& item);
-
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
     /// @return Whether the cache constraint is satisfied.

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -16,10 +16,61 @@ template<typename Key, typename KeyHash, typename Value> class ConstraintCount
     using CacheItem = Item<Value>;
 
 public:
+    class InsertionTicket
+    {
+        friend class ConstraintCount;
+
+    public:
+        [[nodiscard]] bool is_satisfiable() const
+        {
+            return m_satisfiable;
+        }
+
+        [[nodiscard]] bool is_satisfied() const
+        {
+            return m_count_freed >= m_count_to_free;
+        }
+
+        void register_eviction([[maybe_unused]] const Key& key, [[maybe_unused]] const CacheItem& item)
+        {
+            ++m_count_freed;
+        }
+
+    private:
+        InsertionTicket(size_t count_to_free, bool satisfiable) : m_count_to_free{count_to_free}, m_satisfiable{satisfiable}
+        {
+        }
+
+        size_t m_count_to_free;
+        bool   m_satisfiable;
+        size_t m_count_freed{};
+    };
+
+    class ReplacementTicket
+    {
+    public:
+        [[nodiscard]] bool is_satisfiable() const
+        {
+            return true;
+        }
+
+        [[nodiscard]] bool is_satisfied() const
+        {
+            return true;
+        }
+
+        void register_eviction([[maybe_unused]] const Key& key, [[maybe_unused]] const CacheItem& item)
+        {
+        }
+    };
+
     explicit ConstraintCount(size_t maximum_count);
 
     /// @brief Clears the policy.
     void clear();
+
+    [[nodiscard]] InsertionTicket   prepare_insert(const Key& key, const CacheItem& item);
+    [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Determines whether an insertion candidate can be added into the cache.
     /// @details That is, whether the constraint would still be satisfied after inserting the candidate.
@@ -27,14 +78,6 @@ public:
     /// @param item The candidate item.
     /// @return Whether the item can be added in cache.
     [[nodiscard]] bool can_add(const Key& key, const CacheItem& item);
-
-    /// @brief Determines whether an item already in cache can be updated.
-    /// @details That is, whether the key can be updated to the new value while still satisfying the constraint.
-    /// @param key The key to be updated.
-    /// @param old_item The current value of the key in cache.
-    /// @param new_item The value that would replace the current value.
-    /// @return Whether the item can be replaced.
-    [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
@@ -81,18 +124,16 @@ template<class K, class KH, class V> void ConstraintCount<K, KH, V>::clear()
     m_count = 0;
 }
 
-template<class K, class KH, class V> bool ConstraintCount<K, KH, V>::can_add(const K& /* key */, const CacheItem& /* item */)
+template<class K, class KH, class V> auto ConstraintCount<K, KH, V>::prepare_insert(const K& /* key */, const CacheItem& /* item */) -> InsertionTicket
 {
-    return m_count < m_maximum_count;
+    const size_t count_to_free = (m_count + 1 > m_maximum_count) ? ((m_count + 1) - m_maximum_count) : 0;
+    return InsertionTicket{count_to_free, m_maximum_count > 0};
 }
 
 template<class K, class KH, class V>
-bool ConstraintCount<K, KH, V>::can_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */)
+auto ConstraintCount<K, KH, V>::prepare_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */) -> ReplacementTicket
 {
-    assert(m_count > 0);
-
-    // Replacement doesn't change the count, so it's always allowed.
-    return true;
+    return ReplacementTicket{};
 }
 
 template<class K, class KH, class V> bool ConstraintCount<K, KH, V>::is_satisfied()

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
 
 #include <cachemere/item.h>
 
@@ -16,6 +17,78 @@ template<typename Key, typename KeyHash, typename Value> class ConstraintMemory
     using CacheItem = Item<Value>;
 
 public:
+    class InsertionTicket
+    {
+        friend class ConstraintMemory;
+
+    public:
+        [[nodiscard]] bool is_satisfiable() const
+        {
+            return m_satisfiable;
+        }
+
+        [[nodiscard]] bool is_satisfied() const
+        {
+            return m_memory_freed >= m_memory_to_free;
+        }
+
+        void register_eviction([[maybe_unused]] const Key& key, const CacheItem& item)
+        {
+            m_memory_freed += item.m_total_size;
+        }
+
+    private:
+        InsertionTicket(size_t memory_to_free, bool satisfiable) : m_memory_to_free{memory_to_free}, m_satisfiable{satisfiable}
+        {
+        }
+
+        size_t m_memory_to_free;
+        bool   m_satisfiable;
+        size_t m_memory_freed{};
+    };
+
+    class ReplacementTicket
+    {
+        friend class ConstraintMemory;
+
+    public:
+        [[nodiscard]] bool is_satisfiable() const
+        {
+            return m_satisfiable;
+        }
+
+        [[nodiscard]] bool is_satisfied() const
+        {
+            const size_t required_memory_to_free = m_evicted_original_key ? m_memory_to_free_with_insert : m_memory_to_free_with_replace;
+            return m_memory_freed >= required_memory_to_free;
+        }
+
+        void register_eviction(const Key& key, const CacheItem& item)
+        {
+            if (!m_evicted_original_key && key == m_original_key.get()) {
+                m_evicted_original_key = true;
+            }
+
+            m_memory_freed += item.m_total_size;
+        }
+
+    private:
+        ReplacementTicket(const Key& original_key, size_t memory_to_free_with_replace, size_t memory_to_free_with_insert, bool satisfiable)
+         : m_original_key{original_key},
+           m_memory_to_free_with_replace{memory_to_free_with_replace},
+           m_memory_to_free_with_insert{memory_to_free_with_insert},
+           m_satisfiable{satisfiable}
+        {
+        }
+
+        std::reference_wrapper<const Key> m_original_key;
+        size_t                            m_memory_to_free_with_replace;
+        size_t                            m_memory_to_free_with_insert;
+        bool                              m_satisfiable;
+        bool                              m_evicted_original_key{};
+        size_t                            m_memory_freed{};
+    };
+
     /// @brief Constructor.
     /// @param max_memory The maximum amount of memory to be used by the cache, in bytes.
     explicit ConstraintMemory(size_t max_memory);
@@ -28,15 +101,15 @@ public:
     /// @param key The key of the insertion candidate.
     /// @param item The candidate item.
     /// @return Whether the item can be added in cache.
-    [[nodiscard]] bool can_add(const Key& key, const CacheItem& item);
+    [[nodiscard]] InsertionTicket prepare_insert(const Key& key, const CacheItem& item);
 
-    /// @brief Determines whether an item already in cache can be updated.
-    /// @details That is, whether the key can be updated to the new value while still satisfying the constraint.
-    /// @param key The key to be updated.
+    /// @brief Determines how much memory would need to be freed to insert a candidate.
+    /// @details The returned ticket can be updated with evictions until it becomes satisfied.
+    /// @param key The key of the insertion candidate.
     /// @param old_item The current value of the key in cache.
     /// @param new_item The value that would replace the current value.
-    /// @return Whether the item can be replaced.
-    [[nodiscard]] bool can_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    /// @return A ticket describing whether the replacement can be satisfied.
+    [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
 
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
@@ -90,15 +163,25 @@ template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::clear()
     m_memory = 0;
 }
 
-template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::can_add(const K& /* key */, const CacheItem& item)
+template<class K, class KH, class V> auto ConstraintMemory<K, KH, V>::prepare_insert(const K& /* key */, const CacheItem& item) -> InsertionTicket
 {
-    return (m_memory + item.m_total_size) <= m_maximum_memory;
+    const size_t memory_to_free = (m_memory + item.m_total_size > m_maximum_memory) ? ((m_memory + item.m_total_size) - m_maximum_memory) : 0;
+    return InsertionTicket{memory_to_free, item.m_total_size <= m_maximum_memory};
 }
 
-template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::can_replace(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+template<class K, class KH, class V>
+auto ConstraintMemory<K, KH, V>::prepare_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item) -> ReplacementTicket
 {
     assert(old_item.m_key_size == new_item.m_key_size);  // Key size *really* shouldn't have changed since the key is supposed to be const.
-    return ((m_memory - old_item.m_value_size) + new_item.m_value_size) <= m_maximum_memory;
+
+    const size_t memory_to_free_with_replace = ((m_memory - old_item.m_value_size) + new_item.m_value_size > m_maximum_memory)
+                                                   ? (((m_memory - old_item.m_value_size) + new_item.m_value_size) - m_maximum_memory)
+                                                   : 0;
+
+    const size_t memory_to_free_with_insert =
+        (m_memory + new_item.m_total_size > m_maximum_memory) ? ((m_memory + new_item.m_total_size) - m_maximum_memory) : 0;
+
+    return ReplacementTicket{key, memory_to_free_with_replace, memory_to_free_with_insert, new_item.m_total_size <= m_maximum_memory};
 }
 
 template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::is_satisfied()

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -6,7 +6,6 @@
 #include <set>
 
 #include <absl/container/btree_map.h>
-
 #include <cachemere/item.h>
 
 #include "detail/counting_bloom_filter.h"
@@ -42,24 +41,23 @@ private:
     using PrioritySetIt = typename PrioritySet::const_iterator;
 
 public:
-    using CacheItem = Item<Value>;
+    /// @brief Eviction event struct, containing the key and the coefficient of the evicted item.
+    /// @details This struct is used to rollback the policy state in case of an aborted insert.
+    struct EvictionTicket {
+        EvictionTicket(PriorityEntry entry) : m_entry{std::move(entry)}
+        {
+        }
 
-    /// @brief Iterator for iterating over cache items in the order they should be
-    ///        evicted.
-    class VictimIterator
-    {
-    public:
-        VictimIterator(PrioritySetIt iterator);
+        const Key& key() const
+        {
+            return m_entry.m_key;
+        }
 
-        const Key&      operator*() const;
-        VictimIterator& operator++();
-        VictimIterator  operator++(int);
-        bool            operator==(const VictimIterator& other) const;
-        bool            operator!=(const VictimIterator& other) const;
-
-    private:
-        PrioritySetIt m_iterator;
+        PriorityEntry m_entry;
     };
+
+    using CacheItem = Item<Value>;
+    using Ticket    = EvictionTicket;
 
     /// @brief Clears the policy.
     void clear();
@@ -97,13 +95,25 @@ public:
     /// @param item The item that was evicted.
     void on_evict(const Key& key, const CacheItem& item);
 
-    /// @brief Get an iterator to the first item that should be evicted.
-    /// @return An item iterator.
-    [[nodiscard]] VictimIterator victim_begin() const;
+    Ticket pop_victim()
+    {
+        assert(!m_priority_set.empty());
 
-    /// @brief Get an end iterator.
-    /// @return The end iterator.
-    [[nodiscard]] VictimIterator victim_end() const;
+        auto          victim_it    = m_priority_set.begin();
+        PriorityEntry victim_entry = *victim_it;
+        m_priority_set.erase(victim_it);
+        m_iterator_map.erase(victim_entry.m_key);
+        return Ticket{std::move(victim_entry)};
+    }
+
+    void rollback(Ticket ticket)
+    {
+        const Key& victim_key = ticket.key();
+        assert(m_iterator_map.find(std::ref(victim_key)) == m_iterator_map.end());
+
+        const auto it = m_priority_set.emplace(std::move(ticket.m_entry));
+        m_iterator_map.emplace(std::ref(victim_key), it);
+    }
 
 private:
     using IteratorMap = absl::btree_map<KeyRef, PrioritySetIt, std::less<const Key>>;
@@ -113,9 +123,7 @@ private:
     detail::CountingBloomFilter<KeyHash> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with a count-min sketch to get rid of cardinality
 
     PrioritySet m_priority_set;  // A multiset of keys sorted by H-coefficients in ascending order.
-
-    IteratorMap m_iterator_map;  // A map of keys pointing to the corresponding iterator in the priority set. This is necessary because since PrioritySet uses
-                                 // coefficients to compare items to one another, we can't test for key membership directly.
+    IteratorMap m_iterator_map;  // A map of keys pointing to the corresponding iterator in the priority set.
 
     uint64_t m_clock{0};
 
@@ -134,41 +142,6 @@ bool EvictionGDSF<Key, KeyHash, Value, Cost>::PriorityEntry::operator<(const Pri
     return m_h_coefficient < other.m_h_coefficient;
 }
 
-template<class Key, class KeyHash, class Value, class Cost>
-EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::VictimIterator(PrioritySetIt iterator) : m_iterator(std::move(iterator))
-{
-}
-
-template<class Key, class KeyHash, class Value, class Cost> const Key& EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator*() const
-{
-    return m_iterator->m_key;
-}
-
-template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator++() -> VictimIterator&
-{
-    ++m_iterator;
-    return *this;
-}
-
-template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator++(int) -> VictimIterator
-{
-    auto tmp = *this;
-    ++m_iterator;
-    return tmp;
-}
-
-template<class Key, class KeyHash, class Value, class Cost>
-bool EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator==(const VictimIterator& other) const
-{
-    return m_iterator == other.m_iterator;
-}
-
-template<class Key, class KeyHash, class Value, class Cost>
-bool EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator!=(const VictimIterator& other) const
-{
-    return m_iterator != other.m_iterator;
-}
-
 template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::clear()
 {
     m_priority_set.clear();
@@ -185,9 +158,10 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
 {
     m_frequency_sketch.add(key);
 
-    PrioritySetIt it                          = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
-    [[maybe_unused]] const auto [_, inserted] = m_iterator_map.emplace(std::ref(key), it);
-    assert(inserted);
+    assert(m_iterator_map.find(std::ref(key)) == m_iterator_map.end());
+
+    const auto it = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
+    m_iterator_map.emplace(std::ref(key), it);
 }
 
 template<class Key, class KeyHash, class Value, class Cost>
@@ -201,10 +175,6 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
     auto keyref_and_it = m_iterator_map.find(std::ref(key));
     assert(keyref_and_it != m_iterator_map.end());
 
-    PrioritySetIt it = keyref_and_it->second;
-
-    m_priority_set.erase(it);
-
     m_frequency_sketch.add(key);
     m_priority_set.erase(keyref_and_it->second);
     keyref_and_it->second = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
@@ -215,23 +185,11 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
     auto keyref_and_it = m_iterator_map.find(std::ref(key));
     assert(keyref_and_it != m_iterator_map.end());
 
-    PrioritySetIt it = keyref_and_it->second;
-    m_clock          = std::max(m_clock, static_cast<uint64_t>(it->m_h_coefficient));
+    const auto priority_it = keyref_and_it->second;
+    m_clock                = std::max(m_clock, static_cast<uint64_t>(priority_it->m_h_coefficient));
 
-    m_priority_set.erase(it);
+    m_priority_set.erase(priority_it);
     m_iterator_map.erase(keyref_and_it);
-
-    assert(m_iterator_map.find(key) == m_iterator_map.end());
-}
-
-template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::victim_begin() const -> VictimIterator
-{
-    return VictimIterator{m_priority_set.begin()};
-}
-
-template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::victim_end() const -> VictimIterator
-{
-    return VictimIterator{m_priority_set.end()};
 }
 
 template<class Key, class KeyHash, class Value, class Cost>

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -6,6 +6,7 @@
 #include <set>
 
 #include <absl/container/btree_map.h>
+
 #include <cachemere/item.h>
 
 #include "detail/counting_bloom_filter.h"
@@ -43,8 +44,8 @@ private:
 public:
     /// @brief Eviction event struct, containing the key and the coefficient of the evicted item.
     /// @details This struct is used to rollback the policy state in case of an aborted insert.
-    struct EvictionTicket {
-        EvictionTicket(PriorityEntry entry) : m_entry{std::move(entry)}
+    struct Ticket {
+        Ticket(PriorityEntry entry, uint64_t previous_clock) : m_entry{std::move(entry)}, m_previous_clock{previous_clock}
         {
         }
 
@@ -54,10 +55,10 @@ public:
         }
 
         PriorityEntry m_entry;
+        uint64_t      m_previous_clock;
     };
 
     using CacheItem = Item<Value>;
-    using Ticket    = EvictionTicket;
 
     /// @brief Clears the policy.
     void clear();
@@ -103,7 +104,11 @@ public:
         PriorityEntry victim_entry = *victim_it;
         m_priority_set.erase(victim_it);
         m_iterator_map.erase(victim_entry.m_key);
-        return Ticket{std::move(victim_entry)};
+
+        const uint64_t previous_clock = m_clock;
+        update_clock(static_cast<uint64_t>(victim_entry.m_h_coefficient));
+
+        return Ticket{std::move(victim_entry), previous_clock};
     }
 
     void rollback(Ticket ticket)
@@ -113,6 +118,9 @@ public:
 
         const auto it = m_priority_set.emplace(std::move(ticket.m_entry));
         m_iterator_map.emplace(std::ref(victim_key), it);
+
+        assert(m_clock >= ticket.m_previous_clock);
+        m_clock = ticket.m_previous_clock;
     }
 
 private:
@@ -128,6 +136,10 @@ private:
     uint64_t m_clock{0};
 
     [[nodiscard]] double get_h_coefficient(const Key& key, const CacheItem& item) const noexcept;
+    void                 update_clock(uint64_t new_clock)
+    {
+        m_clock = std::max(m_clock, new_clock);
+    }
 };
 
 template<class Key, class KeyHash, class Value, class Cost>
@@ -186,7 +198,7 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
     assert(keyref_and_it != m_iterator_map.end());
 
     const auto priority_it = keyref_and_it->second;
-    m_clock                = std::max(m_clock, static_cast<uint64_t>(priority_it->m_h_coefficient));
+    update_clock(static_cast<uint64_t>(priority_it->m_h_coefficient));
 
     m_priority_set.erase(priority_it);
     m_iterator_map.erase(keyref_and_it);

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -152,7 +152,9 @@ template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Ke
 
 template<class Key, class KeyHash, class Value, class Cost> auto EvictionGDSF<Key, KeyHash, Value, Cost>::VictimIterator::operator++(int) -> VictimIterator
 {
-    return (*this)++;
+    auto tmp = *this;
+    ++m_iterator;
+    return tmp;
 }
 
 template<class Key, class KeyHash, class Value, class Cost>
@@ -183,8 +185,9 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
 {
     m_frequency_sketch.add(key);
 
-    PrioritySetIt it              = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
-    m_iterator_map[std::ref(key)] = std::move(it);
+    PrioritySetIt it                          = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
+    [[maybe_unused]] const auto [_, inserted] = m_iterator_map.emplace(std::ref(key), it);
+    assert(inserted);
 }
 
 template<class Key, class KeyHash, class Value, class Cost>
@@ -202,7 +205,9 @@ template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Ke
 
     m_priority_set.erase(it);
 
-    on_insert(key, item);
+    m_frequency_sketch.add(key);
+    m_priority_set.erase(keyref_and_it->second);
+    keyref_and_it->second = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
 }
 
 template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_evict(const Key& key, const CacheItem& /* item */)

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -27,9 +27,8 @@ private:
 public:
     using CacheItem = cachemere::Item<Value>;
 
-    struct EvictionTicket
-    {
-        explicit EvictionTicket(KeyRef key) : m_key{key}
+    struct Ticket {
+        explicit Ticket(KeyRef key) : m_key{key}
         {
         }
 
@@ -40,8 +39,6 @@ public:
 
         KeyRef m_key;
     };
-
-    using Ticket = EvictionTicket;
 
     /// @brief Clears the policy.
     void clear();
@@ -72,7 +69,7 @@ public:
     void on_evict(const Key& key, const CacheItem& item);
 
     [[nodiscard]] Ticket pop_victim();
-    void rollback(Ticket ticket);
+    void                 rollback(Ticket ticket);
 
 private:
     std::list<KeyRef> m_keys;

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -27,24 +27,21 @@ private:
 public:
     using CacheItem = cachemere::Item<Value>;
 
-    /// @brief Iterator for iterating over cache items in the order they should be
-    ///        evicted.
-    class VictimIterator
+    struct EvictionTicket
     {
-    public:
-        using KeyRefReverseIt = typename std::list<KeyRef>::const_reverse_iterator;
+        explicit EvictionTicket(KeyRef key) : m_key{key}
+        {
+        }
 
-        VictimIterator(const KeyRefReverseIt& p_Iterator);
+        [[nodiscard]] const Key& key() const
+        {
+            return m_key;
+        }
 
-        const Key&      operator*() const;
-        VictimIterator& operator++();
-        VictimIterator  operator++(int);
-        bool            operator==(const VictimIterator& other) const;
-        bool            operator!=(const VictimIterator& other) const;
-
-    private:
-        KeyRefReverseIt m_iterator;
+        KeyRef m_key;
     };
+
+    using Ticket = EvictionTicket;
 
     /// @brief Clears the policy.
     void clear();
@@ -74,54 +71,13 @@ public:
     /// @param item The item that was evicted.
     void on_evict(const Key& key, const CacheItem& item);
 
-    /// @brief Get an iterator to the first item that should be evicted.
-    /// @details Considering that the keys are ordered internally from most-recently used
-    ///          to least-recently used, this iterator will effectively walk the internal
-    ///          structure backwards.
-    /// @return An item iterator.
-    [[nodiscard]] VictimIterator victim_begin() const;
-
-    /// @brief Get an end iterator.
-    /// @return The end iterator.
-    [[nodiscard]] VictimIterator victim_end() const;
+    [[nodiscard]] Ticket pop_victim();
+    void rollback(Ticket ticket);
 
 private:
     std::list<KeyRef> m_keys;
     KeyRefMap         m_nodes;
 };
-
-template<class Key, class KeyHash, class Value>
-EvictionLRU<Key, KeyHash, Value>::VictimIterator::VictimIterator(const KeyRefReverseIt& iterator) : m_iterator(iterator)
-{
-}
-
-template<class Key, class KeyHash, class Value> const Key& EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator*() const
-{
-    return *m_iterator;
-}
-
-template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator++() -> VictimIterator&
-{
-    ++m_iterator;
-    return *this;
-}
-
-template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator++(int) -> VictimIterator
-{
-    auto tmp = *this;
-    ++m_iterator;
-    return tmp;
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator==(const VictimIterator& other) const
-{
-    return m_iterator == other.m_iterator;
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator!=(const VictimIterator& other) const
-{
-    return m_iterator != other.m_iterator;
-}
 
 template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::clear()
 {
@@ -168,18 +124,27 @@ template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, V
     } else {
         auto it = m_nodes.find(key);
         assert(it != m_nodes.end());
+        m_keys.erase(it->second);
         m_nodes.erase(it);
     }
 }
 
-template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::victim_begin() const -> VictimIterator
+template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::pop_victim() -> Ticket
 {
-    return VictimIterator{m_keys.rbegin()};
+    assert(!m_keys.empty());
+
+    const KeyRef victim_key = m_keys.back();
+    m_nodes.erase(victim_key);
+    m_keys.pop_back();
+    return Ticket{victim_key};
 }
 
-template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::victim_end() const -> VictimIterator
+template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::rollback(Ticket ticket)
 {
-    return VictimIterator{m_keys.rend()};
+    assert(m_nodes.find(ticket.m_key) == m_nodes.end());
+
+    m_keys.emplace_back(ticket.m_key);
+    m_nodes.emplace(ticket.m_key, std::prev(m_keys.end()));
 }
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -108,7 +108,9 @@ template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, V
 
 template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator++(int) -> VictimIterator
 {
-    return (*this)++;
+    auto tmp = *this;
+    ++m_iterator;
+    return tmp;
 }
 
 template<class Key, class KeyHash, class Value> bool EvictionLRU<Key, KeyHash, Value>::VictimIterator::operator==(const VictimIterator& other) const

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -31,27 +31,22 @@ private:
 public:
     using CacheItem = cachemere::Item<Value>;
 
-    /// @brief Iterator for iterating over cache items in the order they should be
-    //         evicted.
-    class VictimIterator
+    struct EvictionTicket
     {
-    public:
-        using KeyRefReverseIt = typename std::list<KeyRef>::const_reverse_iterator;
+        EvictionTicket(KeyRef key, bool from_probation) : m_key{key}, m_from_probation{from_probation}
+        {
+        }
 
-        VictimIterator(const KeyRefReverseIt& probation_iterator, const KeyRefReverseIt& probation_end_iterator, const KeyRefReverseIt& protected_iterator);
+        [[nodiscard]] const Key& key() const
+        {
+            return m_key;
+        }
 
-        const Key&      operator*() const;
-        VictimIterator& operator++();
-        VictimIterator  operator++(int);
-        bool            operator==(const VictimIterator& other) const;
-        bool            operator!=(const VictimIterator& other) const;
-
-    private:
-        KeyRefReverseIt m_probation_iterator;
-        KeyRefReverseIt m_probation_end_iterator;
-        KeyRefReverseIt m_protected_iterator;
-        bool            m_done_with_probation;
+        KeyRef m_key;
+        bool   m_from_probation;
     };
+
+    using Ticket = EvictionTicket;
 
     /// @brief Clears the policy.
     void clear();
@@ -89,16 +84,8 @@ public:
     /// @param item The item that was evicted.
     void on_evict(const Key& key, const CacheItem& item);
 
-    /// @brief Get an iterator to the first item that should be evicted.
-    /// @details Considering that the keys are ordered internally from most-recently used
-    ///          to least-recently used, this iterator will effectively walk the internal
-    ///          structure backwards.
-    /// @return An item iterator.
-    [[nodiscard]] VictimIterator victim_begin() const;
-
-    /// @brief Get an end iterator.
-    /// @return The end iterator.
-    [[nodiscard]] VictimIterator victim_end() const;
+    [[nodiscard]] Ticket pop_victim();
+    void rollback(Ticket ticket);
 
 private:
     size_t m_protected_segment_size;
@@ -112,52 +99,6 @@ private:
     bool move_to_protected(const Key& key);
     bool pop_to_probation();
 };
-
-template<class Key, class KeyHash, class Value>
-EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::VictimIterator(const KeyRefReverseIt& probation_iterator,
-                                                                          const KeyRefReverseIt& probation_end_iterator,
-                                                                          const KeyRefReverseIt& protected_iterator)
- : m_probation_iterator{probation_iterator},
-   m_probation_end_iterator{probation_end_iterator},
-   m_protected_iterator{protected_iterator},
-   m_done_with_probation{probation_iterator == probation_end_iterator}
-{
-}
-
-template<class Key, class KeyHash, class Value> const Key& EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::operator*() const
-{
-    const auto it = m_done_with_probation ? m_protected_iterator : m_probation_iterator;
-    return *it;
-}
-
-template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::operator++() -> VictimIterator&
-{
-    if (m_done_with_probation) {
-        ++m_protected_iterator;
-    } else {
-        ++m_probation_iterator;
-        m_done_with_probation |= m_probation_iterator == m_probation_end_iterator;
-    }
-    return *this;
-}
-
-template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::operator++(int) -> VictimIterator
-{
-    auto tmp = *this;
-    ++*this;
-    return tmp;
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::operator==(const VictimIterator& other) const
-{
-    return m_protected_iterator == other.m_protected_iterator && m_probation_iterator == other.m_probation_iterator &&
-           m_done_with_probation == other.m_done_with_probation;
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionSegmentedLRU<Key, KeyHash, Value>::VictimIterator::operator!=(const VictimIterator& other) const
-{
-    return !(*this == other);
-}
 
 template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::clear()
 {
@@ -230,14 +171,33 @@ template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, K
     }
 }
 
-template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::victim_begin() const -> VictimIterator
+template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::pop_victim() -> Ticket
 {
-    return VictimIterator{m_probation_list.rbegin(), m_probation_list.rend(), m_protected_list.rbegin()};
+    if (!m_probation_list.empty()) {
+        const KeyRef victim_key = m_probation_list.back();
+        m_probation_nodes.erase(victim_key);
+        m_probation_list.pop_back();
+        return Ticket{victim_key, true};
+    }
+
+    assert(!m_protected_list.empty());
+    const KeyRef victim_key = m_protected_list.back();
+    m_protected_nodes.erase(victim_key);
+    m_protected_list.pop_back();
+    return Ticket{victim_key, false};
 }
 
-template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::victim_end() const -> VictimIterator
+template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::rollback(Ticket ticket)
 {
-    return VictimIterator{m_probation_list.rend(), m_probation_list.rend(), m_protected_list.rend()};
+    if (ticket.m_from_probation) {
+        assert(m_probation_nodes.find(ticket.m_key) == m_probation_nodes.end());
+        m_probation_list.emplace_back(ticket.m_key);
+        m_probation_nodes.emplace(ticket.m_key, std::prev(m_probation_list.end()));
+    } else {
+        assert(m_protected_nodes.find(ticket.m_key) == m_protected_nodes.end());
+        m_protected_list.emplace_back(ticket.m_key);
+        m_protected_nodes.emplace(ticket.m_key, std::prev(m_protected_list.end()));
+    }
 }
 
 template<class Key, class KeyHash, class Value> bool EvictionSegmentedLRU<Key, KeyHash, Value>::move_to_protected(const Key& key)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(cachemere_tests
         src/memory_cache_tests.cpp
         src/cache_tests.cpp
         src/measurement_tests.cpp
+        src/event_dispatch_tests.cpp
         src/detail/heterogeneous_lookup_tests.cpp
         src/policy/constraint_count_tests.cpp
         src/policy/constraint_memory_tests.cpp

--- a/tests/src/event_dispatch_tests.cpp
+++ b/tests/src/event_dispatch_tests.cpp
@@ -48,28 +48,13 @@ template<typename Key, typename KeyHash, typename Value> class TrackingEvictionP
 {
 public:
     using CacheItem = cachemere::Item<Value>;
-    class VictimIterator
+    struct Ticket
     {
     public:
-        const Key& operator*() const
+        [[nodiscard]] const Key& key() const
         {
             assert(false);
             return *static_cast<const Key*>(nullptr);
-        }
-
-        VictimIterator& operator++()
-        {
-            return *this;
-        }
-
-        bool operator==(const VictimIterator&) const
-        {
-            return true;
-        }
-
-        bool operator!=(const VictimIterator&) const
-        {
-            return false;
         }
     };
 
@@ -84,14 +69,13 @@ public:
 
     void on_evict(const Key&, const CacheItem&) {}
 
-    [[nodiscard]] VictimIterator victim_begin() const
+    [[nodiscard]] Ticket pop_victim()
     {
         return {};
     }
 
-    [[nodiscard]] VictimIterator victim_end() const
+    void rollback(Ticket)
     {
-        return {};
     }
 };
 
@@ -99,17 +83,31 @@ template<typename Key, typename KeyHash, typename Value> class TrackingConstrain
 {
 public:
     using CacheItem = cachemere::Item<Value>;
+    struct Ticket
+    {
+        [[nodiscard]] bool is_satisfiable() const
+        {
+            return true;
+        }
+
+        [[nodiscard]] bool is_satisfied() const
+        {
+            return true;
+        }
+
+        void register_eviction(const Key&, const CacheItem&) {}
+    };
 
     void clear() {}
 
-    bool can_add(const Key&, const CacheItem&) const
+    [[nodiscard]] Ticket prepare_insert(const Key&, const CacheItem&) const
     {
-        return true;
+        return {};
     }
 
-    bool can_replace(const Key&, const CacheItem&, const CacheItem&) const
+    [[nodiscard]] Ticket prepare_replace(const Key&, const CacheItem&, const CacheItem&) const
     {
-        return true;
+        return {};
     }
 
     void on_insert(const Key&, const CacheItem&) {}

--- a/tests/src/event_dispatch_tests.cpp
+++ b/tests/src/event_dispatch_tests.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <cassert>
+
+#include "cachemere/cache.h"
+#include "cachemere/item.h"
+#include "cachemere/measurement.h"
+
+namespace {
+
+struct EventCounters {
+    static void reset()
+    {
+        insertion_hits  = 0;
+        eviction_hits   = 0;
+        constraint_hits = 0;
+    }
+
+    inline static int insertion_hits  = 0;
+    inline static int eviction_hits   = 0;
+    inline static int constraint_hits = 0;
+};
+
+template<typename Key, typename KeyHash, typename Value> class TrackingInsertionPolicy
+{
+public:
+    using CacheItem = cachemere::Item<Value>;
+
+    void clear() {}
+
+    bool should_add(const Key&) const
+    {
+        return true;
+    }
+
+    bool should_replace(const Key&, const Key&) const
+    {
+        return true;
+    }
+
+    void on_cache_hit(const Key&, const CacheItem&)
+    {
+        ++EventCounters::insertion_hits;
+    }
+};
+
+template<typename Key, typename KeyHash, typename Value> class TrackingEvictionPolicy
+{
+public:
+    using CacheItem = cachemere::Item<Value>;
+    class VictimIterator
+    {
+    public:
+        const Key& operator*() const
+        {
+            assert(false);
+            return *static_cast<const Key*>(nullptr);
+        }
+
+        VictimIterator& operator++()
+        {
+            return *this;
+        }
+
+        bool operator==(const VictimIterator&) const
+        {
+            return true;
+        }
+
+        bool operator!=(const VictimIterator&) const
+        {
+            return false;
+        }
+    };
+
+    void clear() {}
+
+    void on_insert(const Key&, const CacheItem&) {}
+
+    void on_cache_hit(const Key&, const CacheItem&)
+    {
+        ++EventCounters::eviction_hits;
+    }
+
+    void on_evict(const Key&, const CacheItem&) {}
+
+    [[nodiscard]] VictimIterator victim_begin() const
+    {
+        return {};
+    }
+
+    [[nodiscard]] VictimIterator victim_end() const
+    {
+        return {};
+    }
+};
+
+template<typename Key, typename KeyHash, typename Value> class TrackingConstraintPolicy
+{
+public:
+    using CacheItem = cachemere::Item<Value>;
+
+    void clear() {}
+
+    bool can_add(const Key&, const CacheItem&) const
+    {
+        return true;
+    }
+
+    bool can_replace(const Key&, const CacheItem&, const CacheItem&) const
+    {
+        return true;
+    }
+
+    void on_insert(const Key&, const CacheItem&) {}
+
+    void on_update(const Key&, const CacheItem&, const CacheItem&) {}
+
+    void on_cache_hit(const Key&, const CacheItem&)
+    {
+        ++EventCounters::constraint_hits;
+    }
+
+    void on_evict(const Key&, const CacheItem&) {}
+};
+
+using TrackingCache = cachemere::Cache<int,
+                                       int,
+                                       TrackingInsertionPolicy,
+                                       TrackingEvictionPolicy,
+                                       TrackingConstraintPolicy,
+                                       cachemere::measurement::SizeOf<int>,
+                                       cachemere::measurement::SizeOf<int>>;
+
+}  // namespace
+
+TEST(CacheEventDispatch, CacheHitIsDeliveredOncePerPolicy)
+{
+    EventCounters::reset();
+
+    TrackingCache cache;
+    ASSERT_TRUE(cache.insert(1, 10));
+
+    const auto value = cache.find(1);
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(10, *value);
+
+    EXPECT_EQ(1, EventCounters::insertion_hits);
+    EXPECT_EQ(1, EventCounters::eviction_hits);
+    EXPECT_EQ(1, EventCounters::constraint_hits);
+}

--- a/tests/src/event_dispatch_tests.cpp
+++ b/tests/src/event_dispatch_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
+#include <exception>
 
 #include "cachemere/cache.h"
 #include "cachemere/item.h"
@@ -26,14 +27,16 @@ template<typename Key, typename KeyHash, typename Value> class TrackingInsertion
 public:
     using CacheItem = cachemere::Item<Value>;
 
-    void clear() {}
+    void clear()
+    {
+    }
 
-    bool should_add(const Key&) const
+    [[nodiscard]] bool should_add(const Key&) const
     {
         return true;
     }
 
-    bool should_replace(const Key&, const Key&) const
+    [[nodiscard]] bool should_replace(const Key&, const Key&) const
     {
         return true;
     }
@@ -48,26 +51,30 @@ template<typename Key, typename KeyHash, typename Value> class TrackingEvictionP
 {
 public:
     using CacheItem = cachemere::Item<Value>;
-    struct Ticket
-    {
+    struct Ticket {
     public:
         [[nodiscard]] const Key& key() const
         {
-            assert(false);
-            return *static_cast<const Key*>(nullptr);
+            std::terminate();
         }
     };
 
-    void clear() {}
+    void clear()
+    {
+    }
 
-    void on_insert(const Key&, const CacheItem&) {}
+    void on_insert(const Key&, const CacheItem&)
+    {
+    }
 
     void on_cache_hit(const Key&, const CacheItem&)
     {
         ++EventCounters::eviction_hits;
     }
 
-    void on_evict(const Key&, const CacheItem&) {}
+    void on_evict(const Key&, const CacheItem&)
+    {
+    }
 
     [[nodiscard]] Ticket pop_victim()
     {
@@ -83,8 +90,7 @@ template<typename Key, typename KeyHash, typename Value> class TrackingConstrain
 {
 public:
     using CacheItem = cachemere::Item<Value>;
-    struct Ticket
-    {
+    struct Ticket {
         [[nodiscard]] bool is_satisfiable() const
         {
             return true;
@@ -95,10 +101,14 @@ public:
             return true;
         }
 
-        void register_eviction(const Key&, const CacheItem&) {}
+        void register_eviction(const Key&, const CacheItem&)
+        {
+        }
     };
 
-    void clear() {}
+    void clear()
+    {
+    }
 
     [[nodiscard]] Ticket prepare_insert(const Key&, const CacheItem&) const
     {
@@ -110,16 +120,22 @@ public:
         return {};
     }
 
-    void on_insert(const Key&, const CacheItem&) {}
+    void on_insert(const Key&, const CacheItem&)
+    {
+    }
 
-    void on_update(const Key&, const CacheItem&, const CacheItem&) {}
+    void on_update(const Key&, const CacheItem&, const CacheItem&)
+    {
+    }
 
     void on_cache_hit(const Key&, const CacheItem&)
     {
         ++EventCounters::constraint_hits;
     }
 
-    void on_evict(const Key&, const CacheItem&) {}
+    void on_evict(const Key&, const CacheItem&)
+    {
+    }
 };
 
 using TrackingCache = cachemere::Cache<int,

--- a/tests/src/memory_cache_tests.cpp
+++ b/tests/src/memory_cache_tests.cpp
@@ -103,3 +103,36 @@ TEST(MemoryCacheTest, SizeUpdateNoUnderflow)
     cache.insert(1, SelfSized{11});
     EXPECT_LT(cache.constraint_policy().memory(), 100);
 }
+
+TEST(MemoryCacheTest, ReplaceCanEvictOriginalKeyAndContinue)
+{
+    struct SelfSized {
+        SelfSized(size_t size) : m_size(size)
+        {
+        }
+
+        size_t size() const
+        {
+            return m_size;
+        }
+
+    private:
+        size_t m_size;
+    };
+
+    using CacheT = presets::memory::LRUCache<uint32_t, SelfSized, measurement::Size<SelfSized>, measurement::SizeOf<uint32_t>>;
+
+    CacheT cache{20};
+
+    ASSERT_TRUE(cache.insert(1, SelfSized{1}));  // total size 5
+    ASSERT_TRUE(cache.insert(2, SelfSized{4}));  // total size 8
+    ASSERT_TRUE(cache.insert(3, SelfSized{3}));  // total size 7
+    ASSERT_EQ(cache.constraint_policy().memory(), 20);
+
+    ASSERT_TRUE(cache.insert(1, SelfSized{6}));
+
+    EXPECT_TRUE(cache.contains(1));
+    EXPECT_FALSE(cache.contains(2));
+    EXPECT_TRUE(cache.contains(3));
+    EXPECT_EQ(cache.constraint_policy().memory(), 17);
+}

--- a/tests/src/policy/constraint_count_tests.cpp
+++ b/tests/src/policy/constraint_count_tests.cpp
@@ -21,7 +21,9 @@ TEST(ConstraintCount, InitializesMaxCountAndCount)
 TEST(ConstraintCount, CanAddWhenEnoughRoom)
 {
     TestConstraint constraint{2};
-    EXPECT_TRUE(constraint.can_add("asdf", TestItem{1, 1, 1}));
+    const auto     ticket = constraint.prepare_insert("asdf", TestItem{1, 1, 1});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 }
 
 TEST(ConstraintCount, CanAddWhenFull)
@@ -33,7 +35,9 @@ TEST(ConstraintCount, CanAddWhenFull)
     }
 
     EXPECT_EQ(constraint.count(), 2);
-    EXPECT_FALSE(constraint.can_add("asdf", TestItem{1, 1, 1}));
+    const auto ticket = constraint.prepare_insert("asdf", TestItem{1, 1, 1});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_FALSE(ticket.is_satisfied());
 }
 
 TEST(ConstraintCount, CanReplaceWhenThereIsRoom)
@@ -41,7 +45,9 @@ TEST(ConstraintCount, CanReplaceWhenThereIsRoom)
     TestConstraint constraint{2};
     constraint.on_insert("asdf", TestItem{1, 1, 1});
 
-    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2}));
+    const auto ticket = constraint.prepare_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 }
 
 TEST(ConstraintCount, CanReplaceWhenFull)
@@ -49,7 +55,9 @@ TEST(ConstraintCount, CanReplaceWhenFull)
     TestConstraint constraint{1};
     constraint.on_insert("asdf", TestItem{1, 1, 1});
 
-    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2}));
+    const auto ticket = constraint.prepare_replace("asdf", TestItem{1, 1, 1}, TestItem{2, 2, 2});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 }
 
 TEST(ConstraintCount, OnEvictDecreasesCount)

--- a/tests/src/policy/constraint_memory_tests.cpp
+++ b/tests/src/policy/constraint_memory_tests.cpp
@@ -22,7 +22,9 @@ TEST(ConstraintMemory, CanAddWhenEnoughRoom)
 {
     TestConstraint constraint{10};
 
-    EXPECT_TRUE(constraint.can_add("asdf", TestItem{4, 42, 4}));
+    const auto ticket = constraint.prepare_insert("asdf", TestItem{4, 42, 4});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 }
 
 TEST(ConstraintMemory, CanAddWhenFull)
@@ -30,14 +32,18 @@ TEST(ConstraintMemory, CanAddWhenFull)
     TestConstraint constraint{10};
 
     constraint.on_insert("asdf", TestItem{5, 42, 5});
-    EXPECT_FALSE(constraint.can_add("hjkl", TestItem{1, 42, 1}));
+    const auto ticket = constraint.prepare_insert("hjkl", TestItem{1, 42, 1});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_FALSE(ticket.is_satisfied());
 }
 
 TEST(ConstraintMemory, CanAddWhenItemTooBig)
 {
     TestConstraint constraint{10};
 
-    EXPECT_FALSE(constraint.can_add("asdf", TestItem{5, 42, 6}));
+    const auto ticket = constraint.prepare_insert("asdf", TestItem{5, 42, 6});
+    EXPECT_FALSE(ticket.is_satisfiable());
+    EXPECT_FALSE(ticket.is_satisfied());
 }
 
 TEST(ConstraintMemory, CanReplaceWhenEnoughRoom)
@@ -47,7 +53,9 @@ TEST(ConstraintMemory, CanReplaceWhenEnoughRoom)
 
     EXPECT_EQ(constraint.memory(), 2);
 
-    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 9}));
+    const auto ticket = constraint.prepare_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 9});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 
     constraint.on_update("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 9});
 
@@ -59,7 +67,9 @@ TEST(ConstraintMemory, CanReplaceWhenItemGrewTooMuch)
     TestConstraint constraint{10};
     constraint.on_insert("asdf", TestItem{1, 42, 1});
 
-    EXPECT_FALSE(constraint.can_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 10}));
+    const auto ticket = constraint.prepare_replace("asdf", TestItem{1, 42, 1}, TestItem{1, 42, 10});
+    EXPECT_FALSE(ticket.is_satisfiable());
+    EXPECT_FALSE(ticket.is_satisfied());
 }
 
 TEST(ConstraintMemory, CanReplaceWhenShrunk)
@@ -67,7 +77,9 @@ TEST(ConstraintMemory, CanReplaceWhenShrunk)
     TestConstraint constraint{10};
     constraint.on_insert("asdf", TestItem{1, 42, 9});
 
-    EXPECT_TRUE(constraint.can_replace("asdf", TestItem{1, 42, 9}, TestItem{1, 42, 8}));
+    const auto ticket = constraint.prepare_replace("asdf", TestItem{1, 42, 9}, TestItem{1, 42, 8});
+    EXPECT_TRUE(ticket.is_satisfiable());
+    EXPECT_TRUE(ticket.is_satisfied());
 }
 
 TEST(ConstraintMemory, OnEvictFreesMemory)

--- a/tests/src/policy/eviction_gdsf_tests.cpp
+++ b/tests/src/policy/eviction_gdsf_tests.cpp
@@ -38,6 +38,14 @@ template<typename Policy> void insert_item(std::string key, int32_t value, Polic
     policy.on_insert(key_and_item->first, key_and_item->second);
 }
 
+template<typename Policy> std::string pop_victim_key(Policy& policy)
+{
+    auto victim = policy.pop_victim();
+    auto key    = std::string{victim.key()};
+    policy.rollback(std::move(victim));
+    return key;
+}
+
 TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
 {
     ConstantCostGDSF policy;
@@ -53,7 +61,7 @@ TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
 
     // Since GDSF gives priority to items with a higher cost per byte, using a constant cost favors small items.
     // This means that short_key should be favored over long_key
-    EXPECT_EQ(*policy.victim_begin(), long_key);
+    EXPECT_EQ(pop_victim_key(policy), long_key);
 
     for (size_t i = 0; i < 10; ++i) {
         auto key_and_item = item_store.find(long_key);
@@ -61,7 +69,7 @@ TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
     }
 
     // GDSF does take frequency into account, so touching "this is supposed to be a much longer string" a few times gives it priority again.
-    EXPECT_EQ(*policy.victim_begin(), short_key);
+    EXPECT_EQ(pop_victim_key(policy), short_key);
 
     // But since cost/byte is favored, we can load "a" fewer times and get it to stay in cache
     for (size_t i = 0; i < 4; ++i) {
@@ -69,7 +77,7 @@ TEST(EvictionGDSF, MaximizesCostPerByteWithConstantCost)
         policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
 
-    EXPECT_EQ(*policy.victim_begin(), long_key);
+    EXPECT_EQ(pop_victim_key(policy), long_key);
 }
 
 TEST(EvictionGDSF, MaximizeCostPerByteWithQuadraticCost)
@@ -88,7 +96,7 @@ TEST(EvictionGDSF, MaximizeCostPerByteWithQuadraticCost)
     // Here GDSF still tries to favor cost/byte, but in this scenario cost increases exponentially with size.
     // This means that bigger items are highly favored in cases where the cost of a cache miss grows
     // heavily with size.
-    EXPECT_EQ(*policy.victim_begin(), short_key);
+    EXPECT_EQ(pop_victim_key(policy), short_key);
 
     // We can demonstrate this by accessing the short key more than the long key. The bigger item will still be favored.
     for (size_t i = 0; i < 10; ++i) {
@@ -100,7 +108,7 @@ TEST(EvictionGDSF, MaximizeCostPerByteWithQuadraticCost)
         auto key_and_item = item_store.find(long_key);
         policy.on_cache_hit(key_and_item->first, key_and_item->second);
     }
-    EXPECT_EQ(*policy.victim_begin(), short_key);
+    EXPECT_EQ(pop_victim_key(policy), short_key);
 }
 
 TEST(EvictionGDSF, VictimIteration)
@@ -115,9 +123,15 @@ TEST(EvictionGDSF, VictimIteration)
     }
 
     const std::set<std::string> expected_key_set{keys.begin(), keys.end()};
-    std::set<std::string>       key_set;
-    for (auto it = policy.victim_begin(); it != policy.victim_end(); ++it) {
-        key_set.insert(*it);
+    std::set<std::string>              key_set;
+    std::vector<QuadraticCostGDSF::Ticket> popped_victims;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto victim = policy.pop_victim();
+        key_set.insert(victim.key());
+        popped_victims.push_back(std::move(victim));
+    }
+    for (auto it = popped_victims.rbegin(); it != popped_victims.rend(); ++it) {
+        policy.rollback(std::move(*it));
     }
 
     EXPECT_EQ(key_set, expected_key_set);

--- a/tests/src/policy/eviction_lru_tests.cpp
+++ b/tests/src/policy/eviction_lru_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <ranges>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -27,14 +28,15 @@ void insert_item(std::string key, int32_t value, TestLRU& policy, ItemMap& item_
 void expect_victims(TestLRU& policy, const std::vector<std::string>& expected_victims)
 {
     std::vector<TestLRU::Ticket> popped_victims;
-    std::vector<std::string> victims;
+    std::vector<std::string>     victims;
     for (size_t i = 0; i < expected_victims.size(); ++i) {
         auto victim = policy.pop_victim();
         victims.push_back(victim.key());
-        popped_victims.push_back(std::move(victim));
+        popped_victims.push_back(victim);
     }
-    for (auto it = popped_victims.rbegin(); it != popped_victims.rend(); ++it) {
-        policy.rollback(std::move(*it));
+
+    for (auto& popped_victim : std::ranges::reverse_view(popped_victims)) {
+        policy.rollback(popped_victim);
     }
     EXPECT_EQ(victims, expected_victims);
 }
@@ -51,7 +53,7 @@ TEST(EvictionLRU, EvictionsWithoutReordering)
     insert_item("c", 1337, policy, item_store);
 
     auto victim = policy.pop_victim();
-    policy.rollback(TestLRU::Ticket{victim});
+    policy.rollback(victim);
 
     EXPECT_EQ("a", victim.key());
 }

--- a/tests/src/policy/eviction_lru_tests.cpp
+++ b/tests/src/policy/eviction_lru_tests.cpp
@@ -24,11 +24,17 @@ void insert_item(std::string key, int32_t value, TestLRU& policy, ItemMap& item_
     policy.on_insert(key_and_item->first, key_and_item->second);
 }
 
-void expect_victims(const TestLRU& policy, const std::vector<std::string>& expected_victims)
+void expect_victims(TestLRU& policy, const std::vector<std::string>& expected_victims)
 {
+    std::vector<TestLRU::Ticket> popped_victims;
     std::vector<std::string> victims;
-    for (auto it = policy.victim_begin(); it != policy.victim_end(); ++it) {
-        victims.push_back(*it);
+    for (size_t i = 0; i < expected_victims.size(); ++i) {
+        auto victim = policy.pop_victim();
+        victims.push_back(victim.key());
+        popped_victims.push_back(std::move(victim));
+    }
+    for (auto it = popped_victims.rbegin(); it != popped_victims.rend(); ++it) {
+        policy.rollback(std::move(*it));
     }
     EXPECT_EQ(victims, expected_victims);
 }
@@ -44,9 +50,10 @@ TEST(EvictionLRU, EvictionsWithoutReordering)
     insert_item("b", 18, policy, item_store);
     insert_item("c", 1337, policy, item_store);
 
-    const auto victim = *policy.victim_begin();
+    auto victim = policy.pop_victim();
+    policy.rollback(TestLRU::Ticket{victim});
 
-    EXPECT_EQ("a", victim);
+    EXPECT_EQ("a", victim.key());
 }
 
 TEST(EvictionLRU, NoOpReordering)

--- a/tests/src/policy/eviction_segmented_lru_tests.cpp
+++ b/tests/src/policy/eviction_segmented_lru_tests.cpp
@@ -22,11 +22,17 @@ void insert_item(std::string key, int32_t value, TestSLRU& policy, ItemMap& item
     policy.on_insert(key_and_item->first, key_and_item->second);
 }
 
-void expect_victims(const TestSLRU& policy, std::vector<std::string> expected_victims)
+void expect_victims(TestSLRU& policy, std::vector<std::string> expected_victims)
 {
+    std::vector<TestSLRU::Ticket> popped_victims;
     std::vector<std::string> victims;
-    for (auto it = policy.victim_begin(); it != policy.victim_end(); ++it) {
-        victims.push_back(*it);
+    for (size_t i = 0; i < expected_victims.size(); ++i) {
+        auto victim = policy.pop_victim();
+        victims.push_back(victim.key());
+        popped_victims.push_back(std::move(victim));
+    }
+    for (auto it = popped_victims.rbegin(); it != popped_victims.rend(); ++it) {
+        policy.rollback(std::move(*it));
     }
     EXPECT_EQ(victims, expected_victims);
 }
@@ -46,13 +52,17 @@ TEST(EvictionSegmentedLRU, BasicInsertEvict)
 
     // After the loop, "a" is the coldest item in cache, and is in the probation segment because it wasn't ever loaded.
     // The first victim should be a.
-    EXPECT_EQ("a", *policy.victim_begin());
+    auto victim = policy.pop_victim();
+    EXPECT_EQ("a", victim.key());
+    policy.rollback(std::move(victim));
 
     // If we touch a, it should be promoted to the protected segment.
     // The first victim should now be b.
     auto key_and_item = item_store.find("a");
     policy.on_cache_hit(key_and_item->first, key_and_item->second);
-    EXPECT_EQ("b", *policy.victim_begin());
+    victim = policy.pop_victim();
+    EXPECT_EQ("b", victim.key());
+    policy.rollback(std::move(victim));
 
     // Before this loop, the probation segment contains [e, d, c, b] and the protected segment contains [a].
     for (auto i = 4; i > 0; --i) {
@@ -62,8 +72,7 @@ TEST(EvictionSegmentedLRU, BasicInsertEvict)
 
     // After the last loop, the protected segment should contain [b, c, d, e] and the probation segment should contain [a].
     // This means that requesting an eviction should return a, and then e.
-    EXPECT_EQ("a", *policy.victim_begin());
-    EXPECT_EQ("e", *++policy.victim_begin());
+    expect_victims(policy, {"a", "e", "d", "c", "b"});
 }
 
 TEST(EvictionSegmentedLRU, RandomEvictions)

--- a/tests/src/policy/eviction_segmented_lru_tests.cpp
+++ b/tests/src/policy/eviction_segmented_lru_tests.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <ranges>
 #include <string>
 #include <map>
 
@@ -22,17 +23,19 @@ void insert_item(std::string key, int32_t value, TestSLRU& policy, ItemMap& item
     policy.on_insert(key_and_item->first, key_and_item->second);
 }
 
-void expect_victims(TestSLRU& policy, std::vector<std::string> expected_victims)
+void expect_victims(TestSLRU& policy, const std::vector<std::string>& expected_victims)
 {
     std::vector<TestSLRU::Ticket> popped_victims;
-    std::vector<std::string> victims;
+    std::vector<std::string>      victims;
+
     for (size_t i = 0; i < expected_victims.size(); ++i) {
         auto victim = policy.pop_victim();
         victims.push_back(victim.key());
-        popped_victims.push_back(std::move(victim));
+        popped_victims.push_back(victim);
     }
-    for (auto it = popped_victims.rbegin(); it != popped_victims.rend(); ++it) {
-        policy.rollback(std::move(*it));
+
+    for (auto& popped_victim : std::ranges::reverse_view(popped_victims)) {
+        policy.rollback(popped_victim);
     }
     EXPECT_EQ(victims, expected_victims);
 }
@@ -54,7 +57,7 @@ TEST(EvictionSegmentedLRU, BasicInsertEvict)
     // The first victim should be a.
     auto victim = policy.pop_victim();
     EXPECT_EQ("a", victim.key());
-    policy.rollback(std::move(victim));
+    policy.rollback(victim);
 
     // If we touch a, it should be promoted to the protected segment.
     // The first victim should now be b.
@@ -62,7 +65,7 @@ TEST(EvictionSegmentedLRU, BasicInsertEvict)
     policy.on_cache_hit(key_and_item->first, key_and_item->second);
     victim = policy.pop_victim();
     EXPECT_EQ("b", victim.key());
-    policy.rollback(std::move(victim));
+    policy.rollback(victim);
 
     // Before this loop, the probation segment contains [e, d, c, b] and the protected segment contains [a].
     for (auto i = 4; i > 0; --i) {


### PR DESCRIPTION
## Changes
- Changes the evict-on-insert from pessimistic to optimistic, using a ticket-based eviction mechanism ([src](https://github.com/coveooss/cachemere/pull/40/changes/3d947bd5024c0980ed38e0de980bccd6c5722701))
  - Previous system expected the insert + evicts to fail, copied the eviction policy to non-destructively determine the set of keys to evict, and then performed the eviction
  - New system expects the insert + evicts to succeed, but keeps enough data to rollback if the insert fails (i.e. if a key to be evicted is preferred in cache over the key being inserted).
  - Even in worst-case scenarios, the new system performs less allocations and is overall faster than the old one. 
- Fixes a bug where `on_cache_hit` was called twice on the eviction policy ([src](https://github.com/coveooss/cachemere/pull/40/changes/b12cf07b78150d3524421cd2b506f70cf381a8f1#diff-7eaea97651844729bdb9012411f57e56496116cab151acb9a8c383c422a630efR1050))
- Fixed iterator implementations + misc. refactor in GDSF ([src](https://github.com/coveooss/cachemere/pull/40/changes/418ae7a3dda08b905cabfaa7bbbd199c36857b1d))