### PR TITLE
[IDX-7035] Misc. API improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(cachemere
         INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/cache.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/composite_key.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/hash.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/item.h>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/cachemere/measurement.h>

--- a/include/cachemere.h
+++ b/include/cachemere.h
@@ -11,6 +11,7 @@
 #include "cachemere/policy/insertion_tinylfu.h"
 
 #include "cachemere/cache.h"
+#include "cachemere/composite_key.h"
 #include "cachemere/hash.h"
 #include "cachemere/item.h"
 #include "cachemere/measurement.h"

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -93,7 +93,7 @@ public:
     /// @param key The key to lookup.
     /// @param fn The factory function to generate the value if the key is not in cache.
     /// @return The value associated with the key.
-    template<typename KeyView, detail::traits::FactoryFn<KeyView, Value> Fn> Value find_or_insert(const KeyView& key, Fn&& fn) const;
+    template<typename KeyView, detail::traits::FactoryFn<KeyView, Value> Fn> Value find_or_insert(const KeyView& key, Fn&& fn);
 
     /// @brief Copy the cache contents in the provided container.
     /// @details The container should conform to either of the STL's interfaces for associative
@@ -348,7 +348,7 @@ template<class K,
          class KH,
          bool TS>
 template<typename KeyView, detail::traits::FactoryFn<KeyView, V> Fn>
-V Cache<K, V, I, E, C, SV, SK, KH, TS>::find_or_insert(const KeyView& key, Fn&& fn) const
+V Cache<K, V, I, E, C, SV, SK, KH, TS>::find_or_insert(const KeyView& key, Fn&& fn)
 {
     LockGuard guard(lock());
 
@@ -361,7 +361,7 @@ V Cache<K, V, I, E, C, SV, SK, KH, TS>::find_or_insert(const KeyView& key, Fn&& 
     on_cache_miss(key);
 
     V value = fn(key);
-    const_cast<Cache<K, V, I, E, C, SV, SK, KH, TS>*>(this)->insert(K(key), value);
+    insert(K(key), value);
     return value;
 }
 
@@ -982,7 +982,7 @@ template<class K,
 void Cache<K, V, I, E, C, SV, SK, KH, TS>::remove_popped_victim(DataMapIt it)
 {
     if constexpr (detail::traits::event::HasOnEvict<K, KH, V, I>) {
-        m_eviction_policy->on_evict(it->first, it->second);
+        m_insertion_policy->on_evict(it->first, it->second);
     }
 
     if constexpr (detail::traits::event::HasOnEvict<K, KH, V, C>) {

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -87,6 +87,14 @@ public:
     /// @return The value if `key` is in cache, `std::nullopt` otherwise.
     template<typename KeyView> std::optional<Value> find(const KeyView& key) const;
 
+    /// @brief Find a given key in cache returning the associated value when it exists, or inserting a new value if it doesn't.
+    /// @tparam KeyView The type of the key used for retrieving items.
+    /// @tparam Fn A factory function type, with signature `Value fn(const KeyView& key)`, used to generate the value to insert if the key is not in cache.
+    /// @param key The key to lookup.
+    /// @param fn The factory function to generate the value if the key is not in cache.
+    /// @return The value associated with the key.
+    template<typename KeyView, detail::traits::FactoryFn<KeyView, Value> Fn> Value find_or_insert(const KeyView& key, Fn&& fn) const;
+
     /// @brief Copy the cache contents in the provided container.
     /// @details The container should conform to either of the STL's interfaces for associative
     ///          containers or for sequence containers.
@@ -328,6 +336,33 @@ std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, TS>::find(const KeyView& key) 
 
     on_cache_miss(key);
     return std::nullopt;
+}
+
+template<class K,
+         class V,
+         template<class, class, class> class I,
+         template<class, class, class> class E,
+         template<class, class, class> class C,
+         class SV,
+         class SK,
+         class KH,
+         bool TS>
+template<typename KeyView, detail::traits::FactoryFn<KeyView, V> Fn>
+V Cache<K, V, I, E, C, SV, SK, KH, TS>::find_or_insert(const KeyView& key, Fn&& fn) const
+{
+    LockGuard guard(lock());
+
+    auto key_and_item = m_data.find(key);
+    if (key_and_item != m_data.end()) {
+        on_cache_hit(key_and_item->first, key_and_item->second);
+        return key_and_item->second.m_value;
+    }
+
+    on_cache_miss(key);
+
+    V value = fn(key);
+    const_cast<Cache<K, V, I, E, C, SV, SK, KH, TS>*>(this)->insert(K(key), value);
+    return value;
 }
 
 template<class K,

--- a/include/cachemere/composite_key.h
+++ b/include/cachemere/composite_key.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <tuple>
 #include <utility>
 
@@ -11,7 +12,7 @@ template<typename... Keys> class CompositeKey
 {
 public:
     template<typename... OtherKeys>
-        requires(sizeof...(OtherKeys) == sizeof...(Keys) && (std::constructible_from<Keys, OtherKeys&&> && ...))
+        requires(sizeof...(OtherKeys) == sizeof...(Keys) && (std::constructible_from<Keys, OtherKeys &&> && ...))
     CompositeKey(OtherKeys&&... keys) : m_keys(std::forward<OtherKeys>(keys)...)
     {
     }

--- a/include/cachemere/composite_key.h
+++ b/include/cachemere/composite_key.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "detail/traits.h"
+
+namespace cachemere {
+
+template<typename... Keys> class CompositeKey
+{
+public:
+    template<typename... OtherKeys>
+        requires(sizeof...(OtherKeys) == sizeof...(Keys) && (std::constructible_from<Keys, OtherKeys&&> && ...))
+    CompositeKey(OtherKeys&&... keys) : m_keys(std::forward<OtherKeys>(keys)...)
+    {
+    }
+
+    template<typename... OtherKeys> bool operator==(const CompositeKey<OtherKeys...>& other) const
+    {
+        return m_keys == other.m_keys;
+    }
+
+    template<typename H, typename... S> friend H AbslHashValue(H h, const CompositeKey& key)
+    {
+        std::apply([&](const auto&... keys) { (HashTuple(h, keys), ...); }, key.m_keys);
+
+        return h;
+    }
+
+private:
+    template<typename...> friend class CompositeKey;
+
+    std::tuple<Keys...> m_keys;
+
+    template<typename H, typename T> static void HashTuple(H& h, const T& key)
+    {
+        if constexpr (detail::traits::BasicString<T>) {
+            h = H::combine_contiguous(std::move(h), key.data(), key.size());
+        } else if constexpr (detail::traits::BasicStringView<T>) {
+            h = H::combine_contiguous(std::move(h), key.data(), key.size());
+        } else {
+            h = H::combine(std::move(h), key);
+        }
+    }
+};
+
+}  // namespace cachemere

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -26,6 +26,11 @@ concept ReservableContainer = requires(T t) {
     { t.size() } -> std::convertible_to<size_t>;
 };
 
+template<typename T, typename K, typename V>
+concept FactoryFn = requires(T t, K key) {
+    { t(key) } -> std::convertible_to<V>;
+};
+
 // Traits for cache event handlers.
 namespace event {
 

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -1,11 +1,32 @@
 #pragma once
 
 #include <concepts>
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include <cachemere/item.h>
 
 namespace cachemere::detail::traits {
+
+template<typename T> struct is_basic_string : std::false_type {
+};
+
+template<typename CharT, typename Traits, typename Alloc> struct is_basic_string<std::basic_string<CharT, Traits, Alloc>> : std::true_type {
+};
+
+template<typename T>
+concept BasicString = is_basic_string<std::remove_cvref_t<T>>::value;
+
+template<class T> struct is_basic_string_view : std::false_type {
+};
+
+template<class CharT, class Traits> struct is_basic_string_view<std::basic_string_view<CharT, Traits>> : std::true_type {
+};
+
+template<class T>
+concept BasicStringView = is_basic_string_view<std::remove_cvref_t<T>>::value;
 
 template<typename T, typename... Args>
 concept SequenceContainer = requires(T t, Args... args) {

--- a/include/cachemere/detail/transparent_eq.h
+++ b/include/cachemere/detail/transparent_eq.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <absl/hash/hash.h>
-
 namespace cachemere::detail {
 
 template<typename Key> struct TransparentEq {
@@ -30,7 +28,7 @@ private:
     {
         if constexpr (requires { lhs == rhs; }) {
             return lhs == rhs;
-        } else {
+        } else if constexpr (requires { lhs <=> rhs; }) {
             return (lhs <=> rhs) == 0;
         }
     }

--- a/include/cachemere/detail/transparent_eq.h
+++ b/include/cachemere/detail/transparent_eq.h
@@ -10,19 +10,29 @@ template<typename Key> struct TransparentEq {
 
     bool operator()(const Key& a, const Key& b) const
     {
-        return a == b;
+        return equal(a, b);
     }
 
     template<typename KeyView> bool operator()(const Key& a, const KeyView& b) const
     {
-        // We only require operator==(const Key&) to be defined on the KeyView.
-        return b == a;
+        // We only require equality or three-way comparison against `Key` to be defined on the KeyView.
+        return equal(b, a);
     }
 
     template<typename KeyView> bool operator()(const KeyView& a, const Key& b) const
     {
-        // We only require operator==(const Key&) to be defined on the KeyView.
-        return a == b;
+        // We only require equality or three-way comparison against `Key` to be defined on the KeyView.
+        return equal(a, b);
+    }
+
+private:
+    template<typename Lhs, typename Rhs> static bool equal(const Lhs& lhs, const Rhs& rhs)
+    {
+        if constexpr (requires { lhs == rhs; }) {
+            return lhs == rhs;
+        } else {
+            return (lhs <=> rhs) == 0;
+        }
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(cachemere_tests
         src/measurement_tests.cpp
         src/event_dispatch_tests.cpp
         src/detail/heterogeneous_lookup_tests.cpp
+        src/detail/composite_key_tests.cpp
         src/policy/constraint_count_tests.cpp
         src/policy/constraint_memory_tests.cpp
         src/policy/eviction_lru_tests.cpp

--- a/tests/src/cache_tests.cpp
+++ b/tests/src/cache_tests.cpp
@@ -122,6 +122,33 @@ TYPED_TEST(CacheTest, SingleThread)
     EXPECT_GT(hit_rate, 0.8);
 }
 
+TYPED_TEST(CacheTest, FindOrInsertCachesFactoryResult)
+{
+    auto cache = TestFixture::new_cache(150);
+
+    uint32_t factory_call_count = 0;
+
+    const auto inserted = cache->find_or_insert(7, [&](const uint32_t& key) {
+        ++factory_call_count;
+        return Point3D{key, key, key};
+    });
+
+    EXPECT_EQ(inserted, (Point3D{7, 7, 7}));
+    EXPECT_EQ(factory_call_count, 1);
+
+    const auto fetched = cache->find(7);
+    ASSERT_TRUE(fetched.has_value());
+    EXPECT_EQ(*fetched, inserted);
+
+    const auto cached = cache->find_or_insert(7, [&](const uint32_t&) {
+        ++factory_call_count;
+        return Point3D{99, 99, 99};
+    });
+
+    EXPECT_EQ(cached, inserted);
+    EXPECT_EQ(factory_call_count, 1);
+}
+
 TYPED_TEST(CacheTest, MultiThreadLong)
 {
     const size_t item_count          = 10000;

--- a/tests/src/detail/composite_key_tests.cpp
+++ b/tests/src/detail/composite_key_tests.cpp
@@ -1,0 +1,66 @@
+#include <string>
+#include <string_view>
+
+#include <absl/hash/hash.h>
+#include <gtest/gtest.h>
+
+#include <cachemere.h>
+
+namespace {
+
+using namespace cachemere;
+
+TEST(CompositeKey, CanConstructFromLvalueStrings)
+{
+    std::string first{"alpha"};
+    std::string second{"beta"};
+
+    CompositeKey<std::string, std::string>           key{first, second};
+    CompositeKey<std::string_view, std::string_view> view_key{first, second};
+
+    EXPECT_TRUE(key == view_key);
+}
+
+TEST(CompositeKey, CanCompareDifferentSpecializations)
+{
+    CompositeKey<std::string, std::string>           owned_key{"alpha", "beta"};
+    CompositeKey<std::string_view, std::string_view> same_view_key{"alpha", "beta"};
+    CompositeKey<std::string_view, std::string_view> other_view_key{"alpha", "gamma"};
+
+    EXPECT_TRUE(owned_key == same_view_key);
+    EXPECT_TRUE(same_view_key == owned_key);
+    EXPECT_FALSE(owned_key == other_view_key);
+    EXPECT_FALSE(other_view_key == owned_key);
+}
+
+TEST(CompositeKey, HashesStringsAndStringViewsTheSame)
+{
+    using OwnedKey = CompositeKey<std::string, std::string, std::uint32_t>;
+    using ViewKey  = CompositeKey<std::string_view, std::string_view, std::uint32_t>;
+
+    OwnedKey owned_key{"alpha", "beta", 42U};
+    ViewKey  view_key{"alpha", "beta", 42U};
+
+    EXPECT_EQ(absl::Hash<OwnedKey>{}(owned_key), absl::Hash<ViewKey>{}(view_key));
+}
+
+TEST(CompositeKey, SupportsHeterogeneousLookup)
+{
+    using OwnedKey = CompositeKey<std::string, std::string>;
+    using ViewKey  = CompositeKey<std::string_view, std::string_view>;
+    using Hasher   = MultiHash<OwnedKey, absl::Hash<OwnedKey>, ViewKey, absl::Hash<ViewKey>>;
+    using Cache    = presets::memory::LRUCache<OwnedKey, std::uint32_t, measurement::SizeOf<std::uint32_t>, measurement::SizeOf<OwnedKey>, Hasher>;
+
+    Cache cache{32U * sizeof(std::uint32_t)};
+
+    cache.insert(OwnedKey{"alpha", "beta"}, 7U);
+
+    auto value = cache.find(ViewKey{"alpha", "beta"});
+
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, 7U);
+    EXPECT_TRUE(cache.contains(ViewKey{"alpha", "beta"}));
+    EXPECT_FALSE(cache.contains(ViewKey{"alpha", "gamma"}));
+}
+
+}  // namespace

--- a/tests/src/detail/heterogeneous_lookup_tests.cpp
+++ b/tests/src/detail/heterogeneous_lookup_tests.cpp
@@ -1,3 +1,7 @@
+#include <compare>
+#include <string>
+#include <string_view>
+
 #include <absl/hash/hash.h>
 #include <gtest/gtest.h>
 
@@ -17,6 +21,43 @@ TEST(TransparentEq, CanEqualSelf)
     EXPECT_TRUE(eq(val, std::string_view("asdf")));
     EXPECT_FALSE(eq(val, std::string_view("bing bong")));
     EXPECT_TRUE(eq(val, val.c_str()));
+}
+
+struct SpaceshipType {
+    std::string value;
+
+    std::strong_ordering operator<=>(const SpaceshipType& other) const
+    {
+        return value <=> other.value;
+    }
+};
+
+struct SpaceshipView {
+    std::string_view value;
+
+    std::strong_ordering operator<=>(const SpaceshipType& other) const
+    {
+        return value <=> other.value;
+    }
+};
+
+TEST(TransparentEq, CanEqualWithThreeWayComparison)
+{
+    using EqT = TransparentEq<SpaceshipType>;
+
+    EqT            eq;
+    SpaceshipType  val{"asdf"};
+    SpaceshipType  same{"asdf"};
+    SpaceshipType  other{"bing bong"};
+    SpaceshipView  view{"asdf"};
+    SpaceshipView  other_view{"bing bong"};
+
+    EXPECT_TRUE(eq(val, same));
+    EXPECT_FALSE(eq(val, other));
+    EXPECT_TRUE(eq(val, view));
+    EXPECT_FALSE(eq(val, other_view));
+    EXPECT_TRUE(eq(view, val));
+    EXPECT_FALSE(eq(other_view, val));
 }
 
 TEST(MultiHash, CanHashSingleType)


### PR DESCRIPTION
## Changes
- Add `Cache::find_or_insert()` ([src](https://github.com/coveooss/cachemere/pull/42/changes/513b22ee76f450b684dbba2516afae7e1f841167))
- Use `<=>` operator for comparing keys/key views when possible ([src](https://github.com/coveooss/cachemere/pull/42/changes/51f9843f052bc43315f841603998ff859908b287))
- Add `CompositeKey` ([src](https://github.com/coveooss/cachemere/pull/42/changes/9736f2bf065723e59070be6fec7b0009ec2ef481))