### PR TITLE
IDX-7031 Constrain cache generics with concepts

### DIFF
--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -47,15 +47,15 @@ namespace cachemere {
 /// @tparam MeasureKey A functor returning the size of a cache key.
 /// @tparam KeyHash A default-constructible callable type returning a hash of a key. Defaults to `absl::Hash<Key>`.
 /// @tparam Locking The locking strategy used to protect cache operations. Defaults to `LockingStrategy::Mutex`.
-template<typename Key,
+template<detail::traits::Key Key,
          typename Value,
          template<class, class, class> class InsertionPolicy,
          template<class, class, class> class EvictionPolicy,
          template<class, class, class> class ConstraintPolicy,
-         typename MeasureValue   = measurement::Size<Value>,
-         typename MeasureKey     = measurement::Size<Key>,
-         typename KeyHash        = absl::Hash<Key>,
-         LockingStrategy Locking = LockingStrategy::Mutex>
+         detail::traits::MeasureFor<Value> MeasureValue = measurement::Size<Value>,
+         detail::traits::MeasureFor<Key>   MeasureKey   = measurement::Size<Key>,
+         detail::traits::HasherFor<Key>    KeyHash      = absl::Hash<Key>,
+         LockingStrategy                   Locking      = LockingStrategy::Mutex>
 class Cache
 {
 public:
@@ -112,7 +112,7 @@ public:
     /// @tparam KeyView The type of the key used for retrieving items.
     /// @param key The key whose presence to test.
     /// @return Whether the key is in cache.
-    template<typename KeyView> bool contains(const KeyView& key) const
+    template<detail::traits::LookupKeyFor<Key, KeyHash> KeyView> bool contains(const KeyView& key) const
     {
         const LockGuard guard{lock()};
         return m_data.find(key) != m_data.end();
@@ -281,7 +281,7 @@ public:
     /// @param predicate_fn The predicate function.
     /// @tparam P The type of the predicate function.
     ///           The predicate should have the signature `bool fn(const Key& key, const Value& value)`.
-    template<typename P> void retain(P predicate_fn)
+    template<detail::traits::PredicateFn<Key, Value> P> void retain(P predicate_fn)
     {
         const LockGuard guard{lock()};
         for (auto it = m_data.begin(); it != m_data.end();) {
@@ -298,7 +298,7 @@ public:
     /// @brief Apply a function to all objects in cache.
     /// @param unary_function The function to be applied to all items in cache.
     ///                       The function should have the signature `void fn(const Key& key, const Value& value)`.
-    template<typename F> void for_each(F unary_function)
+    template<detail::traits::UnaryFn<Key, Value> F> void for_each(F unary_function)
     {
         const LockGuard guard{lock()};
         for (const auto& [key, value] : m_data) {
@@ -751,7 +751,7 @@ private:
     }
 };
 
-template<class K,
+template<detail::traits::Key K,
          class V,
          template<class, class, class> class I,
          template<class, class, class> class E,

--- a/include/cachemere/cache.h
+++ b/include/cachemere/cache.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <type_traits>
 #include <vector>
 
 #include <absl/container/node_hash_map.h>
@@ -77,7 +76,17 @@ public:
 
     /// @brief Simple constructor.
     /// @param args Arguments to forward to the constraint policy constructor.
-    template<typename... Args> Cache(Args... args);
+    template<typename... Args>
+    Cache(Args... args)
+     : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
+       m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
+       m_constraint_policy(std::make_unique<MyConstraintPolicy>(std::forward<Args>(args)...)),
+       m_mutex{},
+       m_data{},
+       m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
+       m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
+    {
+    }
 
     /// @brief Constructor to initialize the cache with a set of items.
     /// @details Will insert items in order in the cache as long as the constraint is satisfied.
@@ -85,37 +94,68 @@ public:
     /// @param args Tuple of arguments to forward to the constraint policy constructor.
     /// @warning Items that are imported from the collection are moved out of the container and left
     ///          in an unspecified state. The container itself can be reused after clearing it.
-    template<typename C, typename... Args> Cache(C& collection, std::tuple<Args...> args);
+    template<typename C, typename... Args>
+    Cache(C& collection, std::tuple<Args...> args)
+     : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
+       m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
+       m_constraint_policy(std::move(
+           std::apply([](auto&&... params) { return std::make_unique<MyConstraintPolicy>(std::forward<decltype(params)>(params)...); }, std::move(args)))),
+       m_mutex{},
+       m_data{},
+       m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
+       m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
+    {
+        import(collection);
+    }
 
     /// @brief Check whether a given key is stored in the cache.
     /// @tparam KeyView The type of the key used for retrieving items.
     /// @param key The key whose presence to test.
     /// @return Whether the key is in cache.
-    template<typename KeyView> bool contains(const KeyView& key) const;
+    template<typename KeyView> bool contains(const KeyView& key) const
+    {
+        const LockGuard guard{lock()};
+        return m_data.find(key) != m_data.end();
+    }
 
     /// @brief Find a given key in cache returning the associated value when it exists.
     /// @tparam KeyView The type of the key used for retrieving items.
     /// @param key The key to lookup.
     /// @return The value if `key` is in cache, `std::nullopt` otherwise.
-    template<typename KeyView> std::optional<Value> find(const KeyView& key) const;
+    template<typename KeyView> std::optional<Value> find(const KeyView& key) const
+    {
+        const LockGuard guard{lock()};
+        return find_locked(key);
+    }
 
     /// @brief Try to find a given key in cache without blocking for the cache lock.
     /// @tparam KeyView The type of the key used for retrieving items.
     /// @param key The key to lookup.
     /// @return A result indicating whether the lock was acquired and, if so, whether the key was found.
-    template<typename KeyView> TryFindResult try_find(const KeyView& key) const;
+    template<typename KeyView> TryFindResult try_find(const KeyView& key) const
+    {
+        const LockGuard guard{try_lock()};
+        if (!guard.owns_lock()) {
+            return TryFindResult{false, std::nullopt};
+        }
+        return TryFindResult{true, find_locked(key)};
+    }
 
     /// @brief Try to find a given key in cache, waiting for up to the provided timeout to acquire the lock.
     /// @tparam KeyView The type of the key used for retrieving items.
     /// @param key The key to lookup.
     /// @param timeout The maximum amount of time to wait for the cache lock.
     /// @return A result indicating whether the lock was acquired and, if so, whether the key was found.
-    template<typename KeyView,
-             typename Rep,
-             typename Period,
-             LockingStrategy TimedLocking                                  = Locking,
-             std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int> = 0>
-    TryFindResult try_find(const KeyView& key, const std::chrono::duration<Rep, Period>& timeout) const;
+    template<typename KeyView, typename Rep, typename Period>
+    TryFindResult try_find(const KeyView& key, const std::chrono::duration<Rep, Period>& timeout) const
+        requires(detail::HasTimedLockingV<Locking>)
+    {
+        const LockGuard guard{try_lock(timeout)};
+        if (!guard.owns_lock()) {
+            return TryFindResult{false, std::nullopt};
+        }
+        return TryFindResult{true, find_locked(key)};
+    }
 
     /// @brief Find a given key in cache returning the associated value when it exists, or inserting a new value if it doesn't.
     /// @tparam KeyView The type of the key used for retrieving items.
@@ -123,7 +163,18 @@ public:
     /// @param key The key to lookup.
     /// @param fn The factory function to generate the value if the key is not in cache.
     /// @return The value associated with the key.
-    template<typename KeyView, detail::traits::FactoryFn<KeyView, Value> Fn> Value find_or_insert(const KeyView& key, Fn&& fn);
+    template<typename KeyView, detail::traits::FactoryFn<KeyView, Value> Fn> Value find_or_insert(const KeyView& key, Fn&& fn)
+    {
+        const LockGuard guard{lock()};
+
+        if (const auto found = find_locked(key); found.has_value()) {
+            return *found;
+        }
+
+        Value value = fn(key);
+        insert_locked(Key(key), value);
+        return value;
+    }
 
     /// @brief Copy the cache contents in the provided container.
     /// @details The container should conform to either of the STL's interfaces for associative
@@ -132,7 +183,27 @@ public:
     ///          If the provided container has `size()` and `reserve()` methods, `collect_into` will reserve
     ///          the appropriate amount of space in the container before inserting.
     /// @param container The container in which to insert the items.
-    template<detail::traits::CacheContainer<Key, Value> C> void collect_into(C& container) const;
+    template<detail::traits::CacheContainer<Key, Value> C> void collect_into(C& container) const
+    {
+        using namespace detail;
+
+        const LockGuard guard{lock()};
+
+        // Reserve space if the container has a reserve() method and a size method().
+        if constexpr (traits::ReservableContainer<C>) {
+            container.reserve(container.size() + m_data.size());
+        }
+
+        // Copy the cache contents to the container.
+        for (const auto& [key, cached_item] : m_data) {
+            // Use emplace_back if container is a sequence container, or emplace if container is an associative container.
+            if constexpr (traits::SequenceContainer<C, Key, Value>) {
+                container.emplace_back(key, cached_item.m_value);
+            } else {
+                container.emplace(key, cached_item.m_value);
+            }
+        }
+    }
 
     /// @brief Insert a key/value pair in the cache.
     /// @details If the key is new, the key/value pair will be inserted.
@@ -140,110 +211,297 @@ public:
     /// @param key The key to associate with the value.
     /// @param value The value to store.
     /// @return Whether the item was inserted in cache.
-    bool insert(Key key, Value value);
+    bool insert(Key key, Value value)
+    {
+        const LockGuard guard{lock()};
+        return insert_locked(std::move(key), std::move(value));
+    }
 
     /// @brief Try to insert a key/value pair in the cache without blocking for the cache lock.
     /// @param key The key to associate with the value.
     /// @param value The value to store.
     /// @return A result indicating whether the lock was acquired and, if so, whether the item was inserted.
-    TryInsertResult try_insert(Key key, Value value);
+    TryInsertResult try_insert(Key key, Value value)
+    {
+        const LockGuard guard{try_lock()};
+        if (!guard.owns_lock()) {
+            return TryInsertResult{false, false};
+        }
+        return TryInsertResult{true, insert_locked(std::move(key), std::move(value))};
+    }
 
     /// @brief Try to insert a key/value pair in the cache, waiting for up to the provided timeout to acquire the lock.
     /// @param key The key to associate with the value.
     /// @param value The value to store.
     /// @param timeout The maximum amount of time to wait for the cache lock.
     /// @return A result indicating whether the lock was acquired and, if so, whether the item was inserted.
-    template<typename Rep, typename Period, LockingStrategy TimedLocking = Locking, std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int> = 0>
-    TryInsertResult try_insert(Key key, Value value, const std::chrono::duration<Rep, Period>& timeout);
+    template<typename Rep, typename Period>
+    TryInsertResult try_insert(Key key, Value value, const std::chrono::duration<Rep, Period>& timeout)
+        requires(detail::HasTimedLockingV<Locking>)
+    {
+        const LockGuard guard{try_lock(timeout)};
+        if (!guard.owns_lock()) {
+            return TryInsertResult{false, false};
+        }
+        return TryInsertResult{true, insert_locked(std::move(key), std::move(value))};
+    }
 
     /// @brief Remove a key and its value from the cache.
     /// @details If the key is not present in cache, no operation is taken.
     /// @param key The key to remove from the cache.
     /// @return Whether the key was present in cache.
-    bool remove(const Key& key);
+    bool remove(const Key& key)
+    {
+        const LockGuard guard{lock()};
+        auto            key_and_item = m_data.find(key);
+        if (key_and_item != m_data.end()) {
+            remove(std::move(key_and_item));
+            return true;
+        }
+        return false;
+    }
 
     /// @brief Clears the cache contents.
-    void clear();
+    void clear()
+    {
+        const LockGuard guard{lock()};
+
+        m_data.clear();
+
+        m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+        m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+
+        m_insertion_policy->clear();
+        m_eviction_policy->clear();
+        m_constraint_policy->clear();
+    }
 
     /// @brief Retain all objects matching a predicate.
     /// @details Removes all items for which `predicate_fn` returns false.
     /// @param predicate_fn The predicate function.
     /// @tparam P The type of the predicate function.
     ///           The predicate should have the signature `bool fn(const Key& key, const Value& value)`.
-    template<typename P> void retain(P predicate_fn);
+    template<typename P> void retain(P predicate_fn)
+    {
+        const LockGuard guard{lock()};
+        for (auto it = m_data.begin(); it != m_data.end();) {
+            const CacheItem& item = it->second;
+
+            if (!predicate_fn(it->first, item.m_value)) {
+                remove(it++);
+            } else {
+                ++it;
+            }
+        }
+    }
 
     /// @brief Apply a function to all objects in cache.
     /// @param unary_function The function to be applied to all items in cache.
     ///                       The function should have the signature `void fn(const Key& key, const Value& value)`.
-    template<typename F> void for_each(F unary_function);
+    template<typename F> void for_each(F unary_function)
+    {
+        const LockGuard guard{lock()};
+        for (const auto& [key, value] : m_data) {
+            unary_function(key, value.m_value);
+        }
+    }
 
     /// @brief Swaps the current cache with another cache of the same type.
     /// @details Calls `std::terminate` if the cache runs in thread-safe mode and an exception is thrown while locking its mutex.
     /// @param other The cache to swap this instance with.
-    void swap(CacheType& other) noexcept;
+    void swap(CacheType& other) noexcept
+    {
+        try {
+            // Acquire both cache locks.
+            std::pair<LockGuard, LockGuard> guards{lock_pair(other)};
+
+            using std::swap;
+
+            swap(m_statistics_window_size, other.m_statistics_window_size);
+
+            swap(m_insertion_policy, other.m_insertion_policy);
+            swap(m_eviction_policy, other.m_eviction_policy);
+            swap(m_constraint_policy, other.m_constraint_policy);
+
+            swap(m_data, other.m_data);
+
+            swap(m_hit_rate_acc, other.m_hit_rate_acc);
+            swap(m_byte_hit_rate_acc, other.m_byte_hit_rate_acc);
+        } catch (const std::system_error& e) {
+            // The only exception that can sensibly be thrown in the above block is a `system_error` when acquiring the mutexes of both caches (if the caches
+            // are running in thread-safe mode).
+            //
+            // According to the [reference for std mutexes](https://en.cppreference.com/w/cpp/named_req/Mutex), this exception can be thrown for one of two
+            // reasons:
+            //   - If the calling thread does not have the required privileges.
+            //   - If the implementation determines that acquiring the lock would lead to a deadlock.
+            //
+            // Since both those errors are unrecoverable, we'll validate that the error code is one of the two we expect, and we'll terminate.
+            assert(e.code() == std::errc::operation_not_permitted || e.code() == std::errc::resource_deadlock_would_occur);
+            std::terminate();
+        } catch (...) {
+            // Even though this is technically not possible in the current state of the code, we'll catch any leftover exception to satisfy clang-tidy.
+            std::terminate();
+        }
+    }
 
     /// @brief Get the number of items currently stored in the cache.
     /// @warning This method acquires a mutual exclusion lock to secure the item count.
     ///          Calling this excessively while the cache is under contention will be detrimental to performance.
     /// @return How many items are in cache.
-    [[nodiscard]] size_t number_of_items() const;
+    [[nodiscard]] size_t number_of_items() const
+    {
+        const LockGuard guard{lock()};
+        return m_data.size();
+    }
 
     /// @brief Update the cache constraint.
     /// @details Forwards the update to the constraint and evicts items from the cache until the
     ///          constraint is satisfied.
     /// @param args Arguments to forward to the `Constraint::update()` .
-    template<typename... Args> void update_constraint(Args... args);
+    template<typename... Args> void update_constraint(Args... args)
+    {
+        const LockGuard guard{lock()};
+        m_constraint_policy->update(std::forward<Args>(args)...);
+
+        while (!m_constraint_policy->is_satisfied()) {
+            auto eviction_ticket = m_eviction_policy->pop_victim();
+            auto key_and_item    = m_data.find(eviction_ticket.key());
+
+            // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
+            assert(key_and_item != m_data.end());
+
+            remove_popped_victim(key_and_item);
+        }
+
+        assert(m_constraint_policy->is_satisfied());
+    }
 
     /// @brief Get a reference to the insertion policy used by the cache.
-    [[nodiscard]] MyInsertionPolicy& insertion_policy();
+    [[nodiscard]] MyInsertionPolicy& insertion_policy()
+    {
+        return *m_insertion_policy;
+    }
 
     /// @brief Get a const reference to the insertion policy used by the cache.
-    [[nodiscard]] const MyInsertionPolicy& insertion_policy() const;
+    [[nodiscard]] const MyInsertionPolicy& insertion_policy() const
+    {
+        return *m_insertion_policy;
+    }
 
     /// @brief Get a reference to the eviction policy used by the cache.
-    [[nodiscard]] MyEvictionPolicy& eviction_policy();
+    [[nodiscard]] MyEvictionPolicy& eviction_policy()
+    {
+        return *m_eviction_policy;
+    }
 
     /// @brief Get a const reference to the eviction policy used by the cache.
-    [[nodiscard]] const MyEvictionPolicy& eviction_policy() const;
+    [[nodiscard]] const MyEvictionPolicy& eviction_policy() const
+    {
+        return *m_eviction_policy;
+    }
 
     /// @brief Get a reference to the constraint policy used by the cache.
-    [[nodiscard]] MyConstraintPolicy& constraint_policy();
+    [[nodiscard]] MyConstraintPolicy& constraint_policy()
+    {
+        return *m_constraint_policy;
+    }
 
     /// @brief Get a const reference to the constraint policy used by the cache.
-    [[nodiscard]] const MyConstraintPolicy& constraint_policy() const;
+    [[nodiscard]] const MyConstraintPolicy& constraint_policy() const
+    {
+        return *m_constraint_policy;
+    }
 
     /// @brief Compute and return the running hit rate of the cache.
     /// @details The hit rate is computed using a sliding window determined by the sliding window
     ///          size passed to the constructor.
     /// @return The hit rate, as a fraction.
-    [[nodiscard]] double hit_rate() const;
+    [[nodiscard]] double hit_rate() const
+    {
+        return boost::accumulators::rolling_mean(m_hit_rate_acc);
+    }
 
     /// @brief Compute and return the running byte hit rate of the cache, in bytes.
     /// @details The byte hit rate represents the average amount of data saved by cache accesses.
     ///          This is a very useful metric in applications where item load times scale
     ///          linearly with item size, for instance in a web server.
     /// @return The byte hit rate, in bytes.
-    [[nodiscard]] double byte_hit_rate() const;
+    [[nodiscard]] double byte_hit_rate() const
+    {
+        return boost::accumulators::rolling_mean(m_byte_hit_rate_acc);
+    }
 
     /// @brief Get the size of the sliding window used for computing statistics.
     /// @return The size of the statistics sliding window.
-    [[nodiscard]] uint32_t statistics_window_size() const;
+    [[nodiscard]] uint32_t statistics_window_size() const
+    {
+        return m_statistics_window_size;
+    }
 
     /// @brief Set the size of the sliding window used for computing statistics.
     /// @warning This will reset the access log, so cache accesses made prior to calling this will not be
     ///          counted in the statistics.
     /// @param window_size The desired statistics window size.
-    void statistics_window_size(uint32_t window_size);
+    void statistics_window_size(uint32_t window_size)
+    {
+        m_statistics_window_size = window_size;
+
+        m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+        m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
+    }
 
 protected:
-    LockGuard lock() const;
-    LockGuard try_lock() const;
-    LockGuard lock(std::defer_lock_t defer_lock_tag) const;
-    template<typename Rep, typename Period, LockingStrategy TimedLocking = Locking, std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int> = 0>
-    LockGuard                       try_lock(const std::chrono::duration<Rep, Period>& timeout) const;
-    std::pair<LockGuard, LockGuard> lock_pair(CacheType& other) const;
+    LockGuard lock() const
+    {
+        return LockGuard{m_mutex};
+    }
 
-    template<typename C> void import(C& collection);
+    LockGuard try_lock() const
+    {
+        return LockGuard{m_mutex, std::try_to_lock};
+    }
+
+    LockGuard lock(std::defer_lock_t defer_lock_tag) const
+    {
+        return LockGuard{m_mutex, defer_lock_tag};
+    }
+
+    template<typename Rep, typename Period>
+    LockGuard try_lock(const std::chrono::duration<Rep, Period>& timeout) const
+        requires(detail::HasTimedLockingV<Locking>)
+    {
+        LockGuard                   guard{m_mutex, std::defer_lock};
+        [[maybe_unused]] const bool locked = guard.try_lock_for(timeout);
+        return guard;
+    }
+
+    std::pair<LockGuard, LockGuard> lock_pair(CacheType& other) const
+    {
+        LockGuard my_guard    = lock(std::defer_lock);
+        LockGuard other_guard = other.lock(std::defer_lock);
+
+        std::lock(my_guard, other_guard);
+
+        return std::make_pair<LockGuard, LockGuard>(std::move(my_guard), std::move(other_guard));
+    }
+
+    template<typename C> void import(C& collection)
+    {
+        const LockGuard guard{lock()};
+
+        for (auto& [key, value] : collection) {
+            const auto key_size   = static_cast<size_t>(m_measure_key(key));
+            const auto value_size = static_cast<size_t>(m_measure_value(value));
+            CacheItem  item{key_size, std::move(value), value_size};
+
+            if (!m_constraint_policy->prepare_insert(key, item).is_satisfied()) {
+                return;
+            }
+
+            insert_or_update(std::move(key), std::move(item));
+        }
+    }
 
 private:
     using CacheItem = Item<Value>;
@@ -275,1027 +533,223 @@ private:
     mutable MeanAccumulator m_hit_rate_acc;
     mutable MeanAccumulator m_byte_hit_rate_acc;
 
-    template<typename KeyView> std::optional<Value> find_locked(const KeyView& key) const;
-    bool                                            insert_locked(Key key, Value value);
-    template<class ConstraintTicket> bool           collect_evictions(const Key& candidate_key, ConstraintTicket& ticket);
-    bool                                            check_insert(const Key& candidate_key, const CacheItem& item);
-    bool                                            check_replace(const Key& candidate_key, const CacheItem& old_item, const CacheItem& new_item);
-
-    void insert_or_update(Key&& key, CacheItem&& value);
-    void remove(DataMapIt it);
-    void remove_popped_victim(DataMapIt it);
-
-    void                            on_insert(const Key& key, const CacheItem& item) const;
-    void                            on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item) const;
-    void                            on_cache_hit(const Key& key, const CacheItem& item) const;
-    template<typename KeyView> void on_cache_miss(const KeyView& key) const;
-    void                            on_evict(const Key& key, const CacheItem& item) const;
-};
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void swap(Cache<K, V, I, E, C, SV, SK, KH, L>& lhs, Cache<K, V, I, E, C, SV, SK, KH, L>& rhs) noexcept;
-
-template<typename Key,
-         typename Value,
-         template<class, class, class> class InsertionPolicy,
-         template<class, class, class> class EvictionPolicy,
-         template<class, class, class> class ConstraintPolicy,
-         typename MeasureValue,
-         typename MeasureKey,
-         typename KeyHash,
-         LockingStrategy Locking>
-template<typename... Args>
-Cache<Key, Value, InsertionPolicy, EvictionPolicy, ConstraintPolicy, MeasureValue, MeasureKey, KeyHash, Locking>::Cache(Args... args)
- : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
-   m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
-   m_constraint_policy(std::make_unique<MyConstraintPolicy>(std::forward<Args>(args)...)),
-   m_mutex{},
-   m_data{},
-   m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
-   m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
-{
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename Coll, typename... Args>
-Cache<K, V, I, E, C, SV, SK, KH, L>::Cache(Coll& collection, std::tuple<Args...> args)
- : m_insertion_policy(std::make_unique<MyInsertionPolicy>()),
-   m_eviction_policy(std::make_unique<MyEvictionPolicy>()),
-   m_constraint_policy(std::move(
-       std::apply([](auto&&... params) { return std::make_unique<MyConstraintPolicy>(std::forward<decltype(params)>(params)...); }, std::move(args)))),
-   m_mutex{},
-   m_data{},
-   m_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size),
-   m_byte_hit_rate_acc(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size)
-{
-    import(collection);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView>
-inline bool Cache<K, V, I, E, C, SV, SK, KH, L>::contains(const KeyView& key) const
-{
-    LockGuard guard(lock());
-    return m_data.find(key) != m_data.end();
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView>
-std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, L>::find_locked(const KeyView& key) const
-{
-    auto key_and_item = m_data.find(key);
-    if (key_and_item != m_data.end()) {
-        on_cache_hit(key_and_item->first, key_and_item->second);
-        return key_and_item->second.m_value;
-    }
-
-    on_cache_miss(key);
-    return std::nullopt;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView>
-std::optional<V> Cache<K, V, I, E, C, SV, SK, KH, L>::find(const KeyView& key) const
-{
-    LockGuard guard(lock());
-    return find_locked(key);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_find(const KeyView& key) const -> TryFindResult
-{
-    LockGuard guard(try_lock());
-    if (!guard.owns_lock()) {
-        return TryFindResult{false, std::nullopt};
-    }
-
-    return TryFindResult{true, find_locked(key)};
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView, typename Rep, typename Period, LockingStrategy TimedLocking, std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int>>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_find(const KeyView& key, const std::chrono::duration<Rep, Period>& timeout) const -> TryFindResult
-{
-    LockGuard guard(try_lock(timeout));
-    if (!guard.owns_lock()) {
-        return TryFindResult{false, std::nullopt};
-    }
-
-    return TryFindResult{true, find_locked(key)};
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename KeyView, detail::traits::FactoryFn<KeyView, V> Fn>
-V Cache<K, V, I, E, C, SV, SK, KH, L>::find_or_insert(const KeyView& key, Fn&& fn)
-{
-    LockGuard guard(lock());
-
-    if (const auto found = find_locked(key); found.has_value()) {
-        return *found;
-    }
-
-    V value = fn(key);
-    insert_locked(K(key), value);
-    return value;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<detail::traits::CacheContainer<K, V> Container>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::collect_into(Container& container) const
-{
-    using namespace detail;
-
-    LockGuard guard(lock());
-
-    // Reserve space if the container has a reserve() method and a size method().
-    if constexpr (traits::ReservableContainer<Container>) {
-        container.reserve(container.size() + m_data.size());
-    }
-
-    // Copy the cache contents to the container.
-    for (const auto& [key, cached_item] : m_data) {
-        // Use emplace_back if container is a sequence container, or emplace if container is an associative container.
-        if constexpr (traits::SequenceContainer<Container, K, V>) {
-            container.emplace_back(key, cached_item.m_value);
-        } else {
-            container.emplace(key, cached_item.m_value);
+    template<typename KeyView> std::optional<Value> find_locked(const KeyView& key) const
+    {
+        const auto key_and_item = m_data.find(key);
+        if (key_and_item != m_data.end()) {
+            on_cache_hit(key_and_item->first, key_and_item->second);
+            return key_and_item->second.m_value;
         }
-    }
-}
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::insert_locked(K key, V value)
-{
-    const auto key_size   = static_cast<size_t>(m_measure_key(key));
-    const auto value_size = static_cast<size_t>(m_measure_value(value));
-
-    CacheItem new_item{key_size, std::move(value), value_size};
-
-    auto it = m_data.find(key);
-    if (it != m_data.end()) {
-        if (check_replace(key, it->second, new_item)) {
-            // We call insert_or_update because we might have evicted the original key to make room for this one.
-            insert_or_update(std::move(key), std::move(new_item));
-            return true;
-        }
-    } else {
-        if (check_insert(key, new_item)) {
-            const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(new_item));
-            assert(it_and_ok.second);
-
-            on_insert(it_and_ok.first->first, it_and_ok.first->second);
-            return true;
-        }
+        on_cache_miss(key);
+        return std::nullopt;
     }
 
-    return false;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::insert(K key, V value)
-{
-    LockGuard guard(lock());
-    return insert_locked(std::move(key), std::move(value));
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_insert(K key, V value) -> TryInsertResult
-{
-    LockGuard guard(try_lock());
-    if (!guard.owns_lock()) {
-        return TryInsertResult{false, false};
-    }
-
-    return TryInsertResult{true, insert_locked(std::move(key), std::move(value))};
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename Rep, typename Period, LockingStrategy TimedLocking, std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int>>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_insert(K key, V value, const std::chrono::duration<Rep, Period>& timeout) -> TryInsertResult
-{
-    LockGuard guard(try_lock(timeout));
-    if (!guard.owns_lock()) {
-        return TryInsertResult{false, false};
-    }
-
-    return TryInsertResult{true, insert_locked(std::move(key), std::move(value))};
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::remove(const K& key)
-{
-    LockGuard guard(lock());
-
-    auto key_and_item = m_data.find(key);
-    if (key_and_item != m_data.end()) {
-        remove(key_and_item);
-        return true;
-    }
-    return false;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::clear()
-{
-    LockGuard guard(lock());
-
-    m_data.clear();
-
-    m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
-    m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
-
-    m_insertion_policy->clear();
-    m_eviction_policy->clear();
-    m_constraint_policy->clear();
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<class P>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::retain(P predicate_fn)
-{
-    LockGuard guard(lock());
-
-    for (auto it = m_data.begin(); it != m_data.end();) {
-        const CacheItem& item = it->second;
-
-        if (!predicate_fn(it->first, item.m_value)) {
-            remove(it++);
-        } else {
-            ++it;
-        }
-    }
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<class F>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::for_each(F unary_function)
-{
-    LockGuard guard(lock());
-    for (const auto& [key, value] : m_data) {
-        unary_function(key, value.m_value);
-    }
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::swap(CacheType& other) noexcept
-{
-    try {
-        // Acquire both cache locks.
-        std::pair<LockGuard, LockGuard> guards{lock_pair(other)};
-
-        using std::swap;
-
-        swap(m_statistics_window_size, other.m_statistics_window_size);
-
-        swap(m_insertion_policy, other.m_insertion_policy);
-        swap(m_eviction_policy, other.m_eviction_policy);
-        swap(m_constraint_policy, other.m_constraint_policy);
-
-        swap(m_data, other.m_data);
-
-        swap(m_hit_rate_acc, other.m_hit_rate_acc);
-        swap(m_byte_hit_rate_acc, other.m_byte_hit_rate_acc);
-    } catch (const std::system_error& e) {
-        // The only exception that can sensibly be thrown in the above block is a `system_error` when acquiring the mutexes of both caches (if the caches
-        // are running in thread-safe mode).
-        //
-        // According to the [reference for std mutexes](https://en.cppreference.com/w/cpp/named_req/Mutex), this exception can be thrown for one of two
-        // reasons:
-        //   - If the calling thread does not have the required privileges.
-        //   - If the implementation determines that acquiring the lock would lead to a deadlock.
-        //
-        // Since both those errors are unrecoverable, we'll validate that the error code is one of the two we expect, and we'll terminate.
-        assert(e.code() == std::errc::operation_not_permitted || e.code() == std::errc::resource_deadlock_would_occur);
-        std::terminate();
-    } catch (...) {
-        // Even though this is technically not possible in the current state of the code, we'll catch any leftover exception to satisfy clang-tidy.
-        std::terminate();
-    }
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline size_t Cache<K, V, I, E, C, SV, SK, KH, L>::number_of_items() const
-{
-    LockGuard guard(lock());
-    return m_data.size();
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename... Args>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::update_constraint(Args... args)
-{
-    LockGuard guard(lock());
-    m_constraint_policy->update(std::forward<Args>(args)...);
-
-    while (!m_constraint_policy->is_satisfied()) {
-        auto eviction_ticket = m_eviction_policy->pop_victim();
-        auto key_and_item    = m_data.find(eviction_ticket.key());
-
-        // If this trips, the eviction policy tried to evict an item not in cache: the eviction policy and the cache are out of sync.
-        assert(key_and_item != m_data.end());
-
-        remove_popped_victim(key_and_item);
-    }
-
-    assert(m_constraint_policy->is_satisfied());
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::insertion_policy() -> MyInsertionPolicy&
-{
-    return *m_insertion_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::insertion_policy() const -> const MyInsertionPolicy&
-{
-    return *m_insertion_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::eviction_policy() -> MyEvictionPolicy&
-{
-    return *m_eviction_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::eviction_policy() const -> const MyEvictionPolicy&
-{
-    return *m_eviction_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::constraint_policy() -> MyConstraintPolicy&
-{
-    return *m_constraint_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline auto Cache<K, V, I, E, C, SV, SK, KH, L>::constraint_policy() const -> const MyConstraintPolicy&
-{
-    return *m_constraint_policy;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline double Cache<K, V, I, E, C, SV, SK, KH, L>::hit_rate() const
-{
-    return boost::accumulators::rolling_mean(m_hit_rate_acc);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline double Cache<K, V, I, E, C, SV, SK, KH, L>::byte_hit_rate() const
-{
-    return boost::accumulators::rolling_mean(m_byte_hit_rate_acc);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline uint32_t Cache<K, V, I, E, C, SV, SK, KH, L>::statistics_window_size() const
-{
-    return m_statistics_window_size;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-inline void Cache<K, V, I, E, C, SV, SK, KH, L>::statistics_window_size(uint32_t window_size)
-{
-    m_statistics_window_size = window_size;
-
-    m_hit_rate_acc      = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
-    m_byte_hit_rate_acc = MeanAccumulator(boost::accumulators::tag::rolling_window::window_size = m_statistics_window_size);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::lock() const -> LockGuard
-{
-    LockGuard guard{m_mutex};
-    return guard;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_lock() const -> LockGuard
-{
-    LockGuard guard{m_mutex, std::try_to_lock};
-    return guard;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::lock([[maybe_unused]] std::defer_lock_t defer_lock_tag) const -> LockGuard
-{
-    LockGuard guard{m_mutex, defer_lock_tag};
-    return guard;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<typename Rep, typename Period, LockingStrategy TimedLocking, std::enable_if_t<detail::HasTimedLockingV<TimedLocking>, int>>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::try_lock(const std::chrono::duration<Rep, Period>& timeout) const -> LockGuard
-{
-    LockGuard                   guard{m_mutex, std::defer_lock};
-    [[maybe_unused]] const bool locked = guard.try_lock_for(timeout);
-    return guard;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-auto Cache<K, V, I, E, C, SV, SK, KH, L>::lock_pair(CacheType& other) const -> std::pair<LockGuard, LockGuard>
-{
-    LockGuard my_guard    = lock(std::defer_lock);
-    LockGuard other_guard = other.lock(std::defer_lock);
-
-    std::lock(my_guard, other_guard);
-
-    return std::make_pair<LockGuard, LockGuard>(std::move(my_guard), std::move(other_guard));
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<class Coll>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::import(Coll& collection)
-{
-    LockGuard guard(lock());
-
-    for (auto& [key, value] : collection) {
+    bool insert_locked(Key key, Value value)
+    {
         const auto key_size   = static_cast<size_t>(m_measure_key(key));
         const auto value_size = static_cast<size_t>(m_measure_value(value));
-        CacheItem  item{key_size, std::move(value), value_size};
 
-        if (!m_constraint_policy->prepare_insert(key, item).is_satisfied()) {
-            return;
-        }
+        CacheItem new_item{key_size, std::move(value), value_size};
 
-        insert_or_update(std::move(key), std::move(item));
-    }
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<class ConstraintTicket>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::collect_evictions(const K& candidate_key, ConstraintTicket& ticket)
-{
-    std::vector<std::pair<typename MyEvictionPolicy::Ticket, DataMapIt>> keys_to_evict;
-
-    while (!ticket.is_satisfied()) {
-        auto eviction_ticket = m_eviction_policy->pop_victim();
-        auto key_and_item    = m_data.find(eviction_ticket.key());
-
-        // If this trips, the eviction policy recommended the eviction of a key not in cache: the eviction policy and the
-        // cache are out of sync.
-        assert(key_and_item != m_data.end());
-
-        if (!m_insertion_policy->should_replace(key_and_item->first, candidate_key)) {
-            m_eviction_policy->rollback(std::move(eviction_ticket));
-            for (auto it = keys_to_evict.rbegin(); it != keys_to_evict.rend(); ++it) {
-                m_eviction_policy->rollback(std::move(it->first));
+        auto it = m_data.find(key);
+        if (it != m_data.end()) {
+            if (check_replace(key, it->second, new_item)) {
+                // We call insert_or_update because we might have evicted the original key to make room for this one.
+                insert_or_update(std::move(key), std::move(new_item));
+                return true;
             }
-            return false;
+        } else {
+            if (check_insert(key, new_item)) {
+                const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(new_item));
+                assert(it_and_ok.second);
+
+                on_insert(it_and_ok.first->first, it_and_ok.first->second);
+                return true;
+            }
         }
 
-        ticket.register_eviction(key_and_item->first, key_and_item->second);
-        keys_to_evict.emplace_back(std::move(eviction_ticket), key_and_item);
-    }
-
-    for (auto& [_, key_and_item] : keys_to_evict) {
-        remove_popped_victim(key_and_item);
-    }
-
-    return true;
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::check_insert(const K& key, const CacheItem& item)
-{
-    auto insertion_ticket = m_constraint_policy->prepare_insert(key, item);
-
-    if (insertion_ticket.is_satisfied()) {
-        // The constraint is already satisfied, so we just check the insertion policy.
-        return m_insertion_policy->should_add(key);
-    }
-
-    if (!insertion_ticket.is_satisfiable()) {
-        return false;  // item can't be inserted even if we evict everything.
-    }
-
-    return collect_evictions(key, insertion_ticket);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-bool Cache<K, V, I, E, C, SV, SK, KH, L>::check_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item)
-{
-    auto replacement_ticket = m_constraint_policy->prepare_replace(key, old_item, new_item);
-
-    if (replacement_ticket.is_satisfied()) {
-        return true;
-    }
-
-    if (!replacement_ticket.is_satisfiable()) {
         return false;
     }
 
-    return collect_evictions(key, replacement_ticket);
-}
+    template<typename ConstraintTicket> bool collect_evictions(const Key& candidate_key, ConstraintTicket& ticket)
+    {
+        std::vector<std::pair<typename MyEvictionPolicy::Ticket, DataMapIt>> keys_to_evict;
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::insert_or_update(K&& key, CacheItem&& item)
-{
-    auto key_and_item = m_data.find(key);
-    if (key_and_item != m_data.end()) {
-        using std::swap;
-        swap(key_and_item->second, item);
-        on_update(key_and_item->first, item, key_and_item->second);
-    } else {
-        // Insert.
-        const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(item));
-        assert(it_and_ok.second);
-        on_insert(it_and_ok.first->first, it_and_ok.first->second);
-    }
-}
+        while (!ticket.is_satisfied()) {
+            auto eviction_ticket = m_eviction_policy->pop_victim();
+            auto key_and_item    = m_data.find(eviction_ticket.key());
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::remove(DataMapIt it)
-{
-    on_evict(it->first, it->second);
-    m_data.erase(it);
-}
+            // If this trips, the eviction policy recommended the eviction of a key not in cache: the eviction policy and the
+            // cache are out of sync.
+            assert(key_and_item != m_data.end());
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::remove_popped_victim(DataMapIt it)
-{
-    if constexpr (detail::traits::event::HasOnEvict<K, KH, V, I>) {
-        m_insertion_policy->on_evict(it->first, it->second);
+            if (!m_insertion_policy->should_replace(key_and_item->first, candidate_key)) {
+                m_eviction_policy->rollback(std::move(eviction_ticket));
+                for (auto it = keys_to_evict.rbegin(); it != keys_to_evict.rend(); ++it) {
+                    m_eviction_policy->rollback(std::move(it->first));
+                }
+                return false;
+            }
+
+            ticket.register_eviction(key_and_item->first, key_and_item->second);
+            keys_to_evict.emplace_back(std::move(eviction_ticket), key_and_item);
+        }
+
+        for (auto& [_, key_and_item] : keys_to_evict) {
+            remove_popped_victim(key_and_item);
+        }
+
+        return true;
     }
 
-    if constexpr (detail::traits::event::HasOnEvict<K, KH, V, C>) {
-        m_constraint_policy->on_evict(it->first, it->second);
+    bool check_insert(const Key& candidate_key, const CacheItem& item)
+    {
+        auto insertion_ticket = m_constraint_policy->prepare_insert(candidate_key, item);
+
+        if (insertion_ticket.is_satisfied()) {
+            // The constraint is already satisfied, so we just check the insertion policy.
+            return m_insertion_policy->should_add(candidate_key);
+        }
+
+        if (!insertion_ticket.is_satisfiable()) {
+            return false;  // item can't be inserted even if we evict everything.
+        }
+
+        return collect_evictions(candidate_key, insertion_ticket);
     }
 
-    m_data.erase(it);
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::on_insert(const K& key, const CacheItem& item) const
-{
-    // Call event handler iif the method is defined in the policy.
-    if constexpr (detail::traits::event::HasOnInsert<K, KH, V, I>) {
-        m_insertion_policy->on_insert(key, item);
+    bool check_replace(const Key& candidate_key, const CacheItem& old_item, const CacheItem& new_item)
+    {
+        auto replacement_ticket = m_constraint_policy->prepare_replace(candidate_key, old_item, new_item);
+        if (replacement_ticket.is_satisfied()) {
+            return true;
+        }
+        if (!replacement_ticket.is_satisfiable()) {
+            return false;
+        }
+        return collect_evictions(candidate_key, replacement_ticket);
     }
 
-    if constexpr (detail::traits::event::HasOnInsert<K, KH, V, E>) {
-        m_eviction_policy->on_insert(key, item);
+    void insert_or_update(Key&& key, CacheItem&& item)
+    {
+        const auto key_and_item = m_data.find(key);
+        if (key_and_item != m_data.end()) {
+            using std::swap;
+            swap(key_and_item->second, item);
+            on_update(key_and_item->first, item, key_and_item->second);
+        } else {
+            // Insert.
+            const auto it_and_ok = m_data.insert_or_assign(std::move(key), std::move(item));
+            assert(it_and_ok.second);
+            on_insert(it_and_ok.first->first, it_and_ok.first->second);
+        }
     }
 
-    if constexpr (detail::traits::event::HasOnInsert<K, KH, V, C>) {
-        m_constraint_policy->on_insert(key, item);
-    }
-}
-
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::on_update(const K& key, const CacheItem& old_item, const CacheItem& new_item) const
-{
-    // Call event handler iif the method is defined in the policy.
-    if constexpr (detail::traits::event::HasOnUpdate<K, KH, V, I>) {
-        m_insertion_policy->on_update(key, old_item, new_item);
+    void remove(DataMapIt it)
+    {
+        on_evict(it->first, it->second);
+        m_data.erase(it);
     }
 
-    if constexpr (detail::traits::event::HasOnUpdate<K, KH, V, E>) {
-        m_eviction_policy->on_update(key, old_item, new_item);
+    void remove_popped_victim(DataMapIt it)
+    {
+        if constexpr (detail::traits::event::HasOnEvict<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_evict(it->first, it->second);
+        }
+        if constexpr (detail::traits::event::HasOnEvict<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_evict(it->first, it->second);
+        }
+        m_data.erase(it);
     }
 
-    if constexpr (detail::traits::event::HasOnUpdate<K, KH, V, C>) {
-        m_constraint_policy->on_update(key, old_item, new_item);
-    }
-}
+    void on_insert(const Key& key, const CacheItem& item) const
+    {
+        // Call event handler iif the method is defined in the policy.
+        if constexpr (detail::traits::event::HasOnInsert<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_insert(key, item);
+        }
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::on_cache_hit(const K& key, const CacheItem& item) const
-{
-    // Update the cache hit rate accumulators.
-    m_hit_rate_acc(1);
-    m_byte_hit_rate_acc(static_cast<uint32_t>(item.m_value_size));
+        if constexpr (detail::traits::event::HasOnInsert<Key, KeyHash, Value, EvictionPolicy>) {
+            m_eviction_policy->on_insert(key, item);
+        }
 
-    // Call event handler iif the method is defined in the policy.
-    if constexpr (detail::traits::event::HasOnCacheHit<K, KH, V, I>) {
-        m_insertion_policy->on_cache_hit(key, item);
+        if constexpr (detail::traits::event::HasOnInsert<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_insert(key, item);
+        }
     }
 
-    if constexpr (detail::traits::event::HasOnCacheHit<K, KH, V, E>) {
-        m_eviction_policy->on_cache_hit(key, item);
+    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item) const
+    {
+        // Call event handler iif the method is defined in the policy.
+        if constexpr (detail::traits::event::HasOnUpdate<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_update(key, old_item, new_item);
+        }
+
+        if constexpr (detail::traits::event::HasOnUpdate<Key, KeyHash, Value, EvictionPolicy>) {
+            m_eviction_policy->on_update(key, old_item, new_item);
+        }
+
+        if constexpr (detail::traits::event::HasOnUpdate<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_update(key, old_item, new_item);
+        }
     }
 
-    if constexpr (detail::traits::event::HasOnCacheHit<K, KH, V, C>) {
-        m_constraint_policy->on_cache_hit(key, item);
-    }
-}
+    void on_cache_hit(const Key& key, const CacheItem& item) const
+    {
+        // Update the cache hit rate accumulators.
+        m_hit_rate_acc(1);
+        m_byte_hit_rate_acc(static_cast<uint32_t>(item.m_value_size));
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-template<class KeyView>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::on_cache_miss(const KeyView& key) const
-{
-    // Update the cache hit rate accumulators.
-    m_hit_rate_acc(0);
-    m_byte_hit_rate_acc(0);
+        // Call event handler iif the method is defined in the policy.
+        if constexpr (detail::traits::event::HasOnCacheHit<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_cache_hit(key, item);
+        }
 
-    // Call event handler iif the method is defined in the policy.
-    if constexpr (detail::traits::event::HasOnCacheMiss<K, KH, V, I>) {
-        m_insertion_policy->on_cache_miss(key);
+        if constexpr (detail::traits::event::HasOnCacheHit<Key, KeyHash, Value, EvictionPolicy>) {
+            m_eviction_policy->on_cache_hit(key, item);
+        }
+
+        if constexpr (detail::traits::event::HasOnCacheHit<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_cache_hit(key, item);
+        }
     }
 
-    if constexpr (detail::traits::event::HasOnCacheMiss<K, KH, V, E>) {
-        m_eviction_policy->on_cache_miss(key);
+    template<typename KeyView> void on_cache_miss(const KeyView& key) const
+    {
+        // Update the cache hit rate accumulators.
+        m_hit_rate_acc(0);
+        m_byte_hit_rate_acc(0);
+
+        // Call event handler iif the method is defined in the policy.
+        if constexpr (detail::traits::event::HasOnCacheMiss<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_cache_miss(key);
+        }
+
+        if constexpr (detail::traits::event::HasOnCacheMiss<Key, KeyHash, Value, EvictionPolicy>) {
+            m_eviction_policy->on_cache_miss(key);
+        }
+
+        if constexpr (detail::traits::event::HasOnCacheMiss<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_cache_miss(key);
+        }
     }
 
-    if constexpr (detail::traits::event::HasOnCacheMiss<K, KH, V, C>) {
-        m_constraint_policy->on_cache_miss(key);
-    }
-}
+    void on_evict(const Key& key, const CacheItem& item) const
+    {
+        if constexpr (detail::traits::event::HasOnEvict<Key, KeyHash, Value, InsertionPolicy>) {
+            m_insertion_policy->on_evict(key, item);
+        }
 
-template<class K,
-         class V,
-         template<class, class, class> class I,
-         template<class, class, class> class E,
-         template<class, class, class> class C,
-         class SV,
-         class SK,
-         class KH,
-         LockingStrategy L>
-void Cache<K, V, I, E, C, SV, SK, KH, L>::on_evict(const K& key, const CacheItem& item) const
-{
-    // Call event handler iif the method is defined in the policy.
-    if constexpr (detail::traits::event::HasOnEvict<K, KH, V, I>) {
-        m_insertion_policy->on_evict(key, item);
-    }
+        if constexpr (detail::traits::event::HasOnEvict<Key, KeyHash, Value, EvictionPolicy>) {
+            m_eviction_policy->on_evict(key, item);
+        }
 
-    if constexpr (detail::traits::event::HasOnEvict<K, KH, V, E>) {
-        m_eviction_policy->on_evict(key, item);
+        if constexpr (detail::traits::event::HasOnEvict<Key, KeyHash, Value, ConstraintPolicy>) {
+            m_constraint_policy->on_evict(key, item);
+        }
     }
-
-    if constexpr (detail::traits::event::HasOnEvict<K, KH, V, C>) {
-        m_constraint_policy->on_evict(key, item);
-    }
-}
+};
 
 template<class K,
          class V,

--- a/include/cachemere/composite_key.h
+++ b/include/cachemere/composite_key.h
@@ -37,7 +37,7 @@ private:
     template<typename H, typename T> static void HashTuple(H& h, const T& key)
     {
         if constexpr (detail::traits::BasicString<T>) {
-            h = H::combine_contiguous(std::move(h), key.data(), key.size());
+            h = H::combine_contiguous(std::move(h), key.c_str(), key.size());
         } else if constexpr (detail::traits::BasicStringView<T>) {
             h = H::combine_contiguous(std::move(h), key.data(), key.size());
         } else {

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/transparent_eq.h>
 
 namespace cachemere::detail::traits {
 
@@ -81,5 +82,35 @@ concept HasOnEvict = requires(P<K, KH, V> policy, K key, Item<V> item) {
 };
 
 }  // namespace event
+
+template<typename T>
+concept Key = std::movable<T> && std::move_constructible<T> && std::assignable_from<T&, T&&> && requires(T t) {
+    { t == t } -> std::convertible_to<bool>;
+};
+
+template<typename T, typename V>
+concept HasherFor = requires(T t, V v) {
+    { t(v) } -> std::convertible_to<size_t>;
+};
+
+template<typename KeyView, typename Key, typename KeyHash>
+concept LookupKeyFor = HasherFor<KeyHash, KeyView> && requires(KeyHash hash, KeyView key_view, Key key) {
+    { TransparentEq<Key>{}(key, key_view) } -> std::same_as<bool>;
+};
+
+template<typename T, typename V>
+concept MeasureFor = requires(T t, V v) {
+    { t(v) } -> std::convertible_to<size_t>;
+};
+
+template<typename T, typename Key, typename Value>
+concept PredicateFn = requires(T t, Key key, Value value) {
+    { t(key, value) } -> std::same_as<bool>;
+};
+
+template<typename T, typename Key, typename Value>
+concept UnaryFn = requires(T t, Key key, Value value) {
+    { t(key, value) } -> std::same_as<void>;
+};
 
 }  // namespace cachemere::detail::traits

--- a/include/cachemere/detail/traits.h
+++ b/include/cachemere/detail/traits.h
@@ -89,7 +89,7 @@ concept Key = std::movable<T> && std::move_constructible<T> && std::assignable_f
 };
 
 template<typename T, typename V>
-concept HasherFor = requires(T t, V v) {
+concept HasherFor = std::default_initializable<T> && requires(T t, V v) {
     { t(v) } -> std::convertible_to<size_t>;
 };
 
@@ -99,7 +99,7 @@ concept LookupKeyFor = HasherFor<KeyHash, KeyView> && requires(KeyHash hash, Key
 };
 
 template<typename T, typename V>
-concept MeasureFor = requires(T t, V v) {
+concept MeasureFor = std::default_initializable<T> && requires(T t, V v) {
     { t(v) } -> std::convertible_to<size_t>;
 };
 

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -12,7 +12,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintCount
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintCount
 {
     using CacheItem = Item<Value>;
 

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -3,7 +3,7 @@
 #include <cassert>
 
 #include <cachemere/item.h>
-#include <endian.h>
+#include <cachemere/detail/traits.h>
 
 namespace cachemere::policy {
 
@@ -12,7 +12,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class ConstraintCount
+template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintCount
 {
     using CacheItem = Item<Value>;
 

--- a/include/cachemere/policy/constraint_count.h
+++ b/include/cachemere/policy/constraint_count.h
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include <cachemere/item.h>
+#include <endian.h>
 
 namespace cachemere::policy {
 
@@ -64,100 +65,80 @@ public:
         }
     };
 
-    explicit ConstraintCount(size_t maximum_count);
+    explicit ConstraintCount(size_t maximum_count)
+    {
+        update(maximum_count);
+    }
 
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_count = 0;
+    }
 
-    [[nodiscard]] InsertionTicket   prepare_insert(const Key& key, const CacheItem& item);
-    [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    [[nodiscard]] InsertionTicket prepare_insert(const Key& /* key */, const CacheItem& /* item */)
+    {
+        const size_t count_to_free = (m_count + 1 > m_maximum_count) ? ((m_count + 1) - m_maximum_count) : 0;
+        return InsertionTicket{count_to_free, m_maximum_count > 0};
+    }
+
+    [[nodiscard]] ReplacementTicket prepare_replace(const Key& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */)
+    {
+        return ReplacementTicket{};
+    }
 
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
     /// @return Whether the cache constraint is satisfied.
-    [[nodiscard]] bool is_satisfied();
+    [[nodiscard]] bool is_satisfied()
+    {
+        return m_count <= m_maximum_count;
+    }
 
     /// @brief Update the cache constraint.
     /// @details Sets a new maximum count.
     /// @param maximum_count The new number of items in cache.
-    void update(size_t maximum_count);
+    void update(size_t maximum_count)
+    {
+        m_maximum_count = maximum_count;
+    }
 
     /// @brief Insertion event handler.
     /// @details Adds one to the number of items in cache.
     /// @param key The key of the inserted item.
     /// @param item The item that has been inserted in cache.
-    void on_insert(const Key& key, const CacheItem& item);
+    void on_insert(const Key& /* key */, const CacheItem& /* item */)
+    {
+        ++m_count;
+    }
 
     /// @brief Eviction event handler.
     /// @details Removes one from the number of items in cache.
     /// @param key The key that was evicted.
     /// @param item The item that was evicted.
-    void on_evict(const Key& key, const CacheItem& item);
+    void on_evict(const Key& /* key */, const CacheItem& /* item */)
+    {
+        assert(m_count > 0);
+        --m_count;
+    }
 
     /// @brief Get the number of items currently in the cache.
     /// @return The number of items in cache.
-    [[nodiscard]] size_t count() const;
+    [[nodiscard]] size_t count() const
+    {
+        return m_count;
+    }
 
     /// @brief Get the maximum number of items allowed in cache.
     /// @return The maximum number of items allowed in cache.
-    [[nodiscard]] size_t maximum_count() const;
+    [[nodiscard]] size_t maximum_count() const
+    {
+        return m_maximum_count;
+    }
 
 private:
     size_t m_maximum_count;
     size_t m_count = 0;
 };
-
-template<class K, class KH, class V> ConstraintCount<K, KH, V>::ConstraintCount(size_t maximum_count)
-{
-    update(maximum_count);
-}
-
-template<class K, class KH, class V> void ConstraintCount<K, KH, V>::clear()
-{
-    m_count = 0;
-}
-
-template<class K, class KH, class V> auto ConstraintCount<K, KH, V>::prepare_insert(const K& /* key */, const CacheItem& /* item */) -> InsertionTicket
-{
-    const size_t count_to_free = (m_count + 1 > m_maximum_count) ? ((m_count + 1) - m_maximum_count) : 0;
-    return InsertionTicket{count_to_free, m_maximum_count > 0};
-}
-
-template<class K, class KH, class V>
-auto ConstraintCount<K, KH, V>::prepare_replace(const K& /* key */, const CacheItem& /* old_item */, const CacheItem& /* new_item */) -> ReplacementTicket
-{
-    return ReplacementTicket{};
-}
-
-template<class K, class KH, class V> bool ConstraintCount<K, KH, V>::is_satisfied()
-{
-    return m_count <= m_maximum_count;
-}
-
-template<class K, class KH, class V> void ConstraintCount<K, KH, V>::update(size_t maximum_count)
-{
-    m_maximum_count = maximum_count;
-}
-
-template<class K, class KH, class V> void ConstraintCount<K, KH, V>::on_insert(const K& /* key */, const CacheItem& /* item */)
-{
-    ++m_count;
-}
-
-template<class K, class KH, class V> void ConstraintCount<K, KH, V>::on_evict(const K& /* key */, const CacheItem& /* item */)
-{
-    assert(m_count > 0);
-    --m_count;
-}
-
-template<class K, class KH, class V> size_t ConstraintCount<K, KH, V>::count() const
-{
-    return m_count;
-}
-
-template<class K, class KH, class V> size_t ConstraintCount<K, KH, V>::maximum_count() const
-{
-    return m_maximum_count;
-}
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -91,17 +91,27 @@ public:
 
     /// @brief Constructor.
     /// @param max_memory The maximum amount of memory to be used by the cache, in bytes.
-    explicit ConstraintMemory(size_t max_memory);
+    explicit ConstraintMemory(size_t max_memory)
+    {
+        update(max_memory);
+    }
 
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_memory = 0;
+    }
 
     /// @brief Determines whether an insertion candidate can be added into the cache.
     /// @details That is, whether the constraint would still be satisfied after inserting the candidate.
     /// @param key The key of the insertion candidate.
     /// @param item The candidate item.
     /// @return Whether the item can be added in cache.
-    [[nodiscard]] InsertionTicket prepare_insert(const Key& key, const CacheItem& item);
+    [[nodiscard]] InsertionTicket prepare_insert(const Key& /* key */, const CacheItem& item)
+    {
+        const size_t memory_to_free = (m_memory + item.m_total_size > m_maximum_memory) ? ((m_memory + item.m_total_size) - m_maximum_memory) : 0;
+        return InsertionTicket{memory_to_free, item.m_total_size <= m_maximum_memory};
+    }
 
     /// @brief Determines how much memory would need to be freed to insert a candidate.
     /// @details The returned ticket can be updated with evictions until it becomes satisfied.
@@ -109,118 +119,85 @@ public:
     /// @param old_item The current value of the key in cache.
     /// @param new_item The value that would replace the current value.
     /// @return A ticket describing whether the replacement can be satisfied.
-    [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    [[nodiscard]] ReplacementTicket prepare_replace(const Key& key, const CacheItem& old_item, const CacheItem& new_item)
+    {
+        assert(old_item.m_key_size == new_item.m_key_size);  // Key size *really* shouldn't have changed since the key is supposed to be const.
+
+        const size_t memory_to_free_with_replace = ((m_memory - old_item.m_value_size) + new_item.m_value_size > m_maximum_memory)
+                                                       ? (((m_memory - old_item.m_value_size) + new_item.m_value_size) - m_maximum_memory)
+                                                       : 0;
+
+        const size_t memory_to_free_with_insert =
+            (m_memory + new_item.m_total_size > m_maximum_memory) ? ((m_memory + new_item.m_total_size) - m_maximum_memory) : 0;
+
+        return ReplacementTicket{key, memory_to_free_with_replace, memory_to_free_with_insert, new_item.m_total_size <= m_maximum_memory};
+    }
 
     /// @brief Returns whether the constraint is satisfied.
     /// @details Used by the cache after a constraint update to compute how many items should be evicted, if any.
     /// @return Whether the cache constraint is satisfied.
-    [[nodiscard]] bool is_satisfied();
+    [[nodiscard]] bool is_satisfied()
+    {
+        return m_memory <= m_maximum_memory;
+    }
 
     /// @brief Update the cache constraint.
     /// @details Sets a new maximum amount of memory.
     /// @param max_memory The new maximum amount of memory to be used by the cache.
-    void update(size_t max_memory);
+    void update(size_t max_memory)
+    {
+        m_maximum_memory = max_memory;
+    }
 
     /// @brief Get the amount of memory currently used by the cache.
     /// @return The current amount of memory used, in bytes.
-    [[nodiscard]] size_t memory() const;
+    [[nodiscard]] size_t memory() const
+    {
+        return m_memory;
+    }
 
     /// @brief Get the maximum amount of memory that can be used by the cache.
     /// @return The maximum amount of memory, in bytes.
-    [[nodiscard]] size_t maximum_memory() const;
+    [[nodiscard]] size_t maximum_memory() const
+    {
+        return m_maximum_memory;
+    }
 
     /// @brief Insertion event handler.
     /// @details Adds the size of this item to the amount of memory used.
     /// @param key The key of the inserted item.
     /// @param item The item that has been inserted in cache.
-    void on_insert(const Key& key, const CacheItem& item);
+    void on_insert(const Key& /* key */, const CacheItem& item)
+    {
+        m_memory += item.m_total_size;
+        assert(m_memory <= m_maximum_memory);
+    }
 
     /// @brief Update event handler.
     /// @details Updates the amount of memory used to reflect the size difference between the old and the new value.
     /// @param key The key that has been updated in the cache.
     /// @param old_item The old value for this key.
     /// @param new_item The new value for this key
-    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    void on_update(const Key& /* key */, const CacheItem& old_item, const CacheItem& new_item)
+    {
+        m_memory -= old_item.m_value_size;
+        m_memory += new_item.m_value_size;
+        assert(m_memory <= m_maximum_memory);
+    }
 
     /// @brief Eviction event handler.
     /// @details Removes the item at the back of the list - ensuring it has the provided key.
     /// @param key The key that was evicted.
     /// @param item The item that was evicted.
-    void on_evict(const Key& key, const CacheItem& item);
+    void on_evict(const Key& /* key */, const CacheItem& item)
+    {
+        assert(item.m_key_size + item.m_value_size <= m_memory);
+        m_memory -= item.m_total_size;
+    }
 
 private:
     size_t m_maximum_memory;
     size_t m_memory = 0;
 };
-
-template<class K, class KH, class V> ConstraintMemory<K, KH, V>::ConstraintMemory(size_t max_memory)
-{
-    update(max_memory);
-}
-
-template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::clear()
-{
-    m_memory = 0;
-}
-
-template<class K, class KH, class V> auto ConstraintMemory<K, KH, V>::prepare_insert(const K& /* key */, const CacheItem& item) -> InsertionTicket
-{
-    const size_t memory_to_free = (m_memory + item.m_total_size > m_maximum_memory) ? ((m_memory + item.m_total_size) - m_maximum_memory) : 0;
-    return InsertionTicket{memory_to_free, item.m_total_size <= m_maximum_memory};
-}
-
-template<class K, class KH, class V>
-auto ConstraintMemory<K, KH, V>::prepare_replace(const K& key, const CacheItem& old_item, const CacheItem& new_item) -> ReplacementTicket
-{
-    assert(old_item.m_key_size == new_item.m_key_size);  // Key size *really* shouldn't have changed since the key is supposed to be const.
-
-    const size_t memory_to_free_with_replace = ((m_memory - old_item.m_value_size) + new_item.m_value_size > m_maximum_memory)
-                                                   ? (((m_memory - old_item.m_value_size) + new_item.m_value_size) - m_maximum_memory)
-                                                   : 0;
-
-    const size_t memory_to_free_with_insert =
-        (m_memory + new_item.m_total_size > m_maximum_memory) ? ((m_memory + new_item.m_total_size) - m_maximum_memory) : 0;
-
-    return ReplacementTicket{key, memory_to_free_with_replace, memory_to_free_with_insert, new_item.m_total_size <= m_maximum_memory};
-}
-
-template<class K, class KH, class V> bool ConstraintMemory<K, KH, V>::is_satisfied()
-{
-    return m_memory <= m_maximum_memory;
-}
-
-template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::update(size_t max_memory)
-{
-    m_maximum_memory = max_memory;
-}
-
-template<class K, class KH, class V> size_t ConstraintMemory<K, KH, V>::memory() const
-{
-    return m_memory;
-}
-
-template<class K, class KH, class V> size_t ConstraintMemory<K, KH, V>::maximum_memory() const
-{
-    return m_maximum_memory;
-}
-
-template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_insert(const K& /* key */, const CacheItem& item)
-{
-    m_memory += item.m_total_size;
-    assert(m_memory <= m_maximum_memory);
-}
-
-template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_update(const K& /* key */, const CacheItem& old_item, const CacheItem& new_item)
-{
-    m_memory -= old_item.m_value_size;
-    m_memory += new_item.m_value_size;
-    assert(m_memory <= m_maximum_memory);
-}
-
-template<class K, class KH, class V> void ConstraintMemory<K, KH, V>::on_evict(const K& /* key */, const CacheItem& item)
-{
-    assert(item.m_total_size <= m_memory);
-    m_memory -= item.m_total_size;
-}
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -13,7 +13,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintMemory
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintMemory
 {
     using CacheItem = Item<Value>;
 

--- a/include/cachemere/policy/constraint_memory.h
+++ b/include/cachemere/policy/constraint_memory.h
@@ -4,6 +4,7 @@
 #include <functional>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/traits.h>
 
 namespace cachemere::policy {
 
@@ -12,7 +13,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class ConstraintMemory
+template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class ConstraintMemory
 {
     using CacheItem = Item<Value>;
 

--- a/include/cachemere/policy/detail/bloom_filter.h
+++ b/include/cachemere/policy/detail/bloom_filter.h
@@ -2,8 +2,6 @@
 
 #include <cstdint>
 
-#include "bloom_filter_math.h"
-
 #ifdef _WIN32
 #    pragma warning(push)
 #    pragma warning(disable : 4244)
@@ -16,6 +14,9 @@
 #    pragma warning(pop)
 #endif
 
+#include <cachemere/detail/traits.h>
+
+#include "bloom_filter_math.h"
 #include "hash_mixer.h"
 
 namespace cachemere::policy::detail {

--- a/include/cachemere/policy/detail/bloom_filter.h
+++ b/include/cachemere/policy/detail/bloom_filter.h
@@ -36,32 +36,70 @@ public:
     ///          while having an estimate that is too low will drastically reduce the accuracy of the filter.
     ///
     /// @param cardinality The expected cardinality of the set to be inserted in the filter.
-    BloomFilter(uint32_t cardinality);
+    BloomFilter(uint32_t cardinality)
+     : m_cardinality{cardinality},
+       m_filter{optimal_filter_size(cardinality), false},
+       m_nb_hashes{optimal_nb_of_hash_functions(cardinality, m_filter.size())}
+    {
+    }
 
     /// @brief Add an item to the filter.
     /// @param item The item to insert.
-    template<typename ItemKey> void add(const ItemKey& item);
+    template<typename ItemKey> void add(const ItemKey& item)
+    {
+        HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
+
+        for (size_t i = 0; i < m_nb_hashes; ++i) {
+            const size_t filter_idx = mixer();
+            assert(filter_idx < m_filter.size());
+
+            m_filter.set(filter_idx);
+        }
+    }
 
     /// @brief Clear the filter while keeping the allocated memory.
-    void clear();
+    void clear()
+    {
+        m_filter.reset();
+    }
 
     /// @brief Test membership of the specified item.
     /// @details A bloom filter can return false positives, but not false negatives.
     ///          This method returning `true` only means that the set _might_ contain the specified item,
     ///          while a return value of `false` means that the set _certainly_ does not contain the specified item.
     /// @param item The item to test.
-    template<typename ItemKey> [[nodiscard]] bool maybe_contains(const ItemKey& item) const;
+    template<typename ItemKey> [[nodiscard]] bool maybe_contains(const ItemKey& item) const
+    {
+        HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
+
+        for (size_t i = 0; i < m_nb_hashes; ++i) {
+            const size_t filter_idx = mixer();
+            assert(filter_idx < m_filter.size());
+
+            if (!m_filter.test(filter_idx)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /// @brief Get an estimate of the memory consumption of the filter.
     /// @return The memory used by the filter, in bytes.
-    [[nodiscard]] size_t memory_used() const noexcept;
+    [[nodiscard]] size_t memory_used() const noexcept
+    {
+        return m_filter.num_blocks() * sizeof(BitsetBlock) + sizeof(m_nb_hashes);
+    }
 
     /// @brief Get the saturation of the filter.
     /// @details As filter saturations increases, so will the probability of false positives.
     ///          A filter saturation of 1.0 means that all underlying bits are set to `1`, so every call to `maybe_contains` will return `true`.
     ///          Increasing the filter cardinality will slow down the saturation of the filter, at the cost of using more memory.
     /// @return The saturation of the filter, as a fraction
-    [[nodiscard]] double saturation() const noexcept;
+    [[nodiscard]] double saturation() const noexcept
+    {
+        assert(m_filter.size() > 0);
+        return static_cast<double>(m_filter.count()) / static_cast<double>(m_filter.size());
+    }
 
 private:
     using BitsetBlock = uint8_t;
@@ -71,57 +109,5 @@ private:
     BitSet   m_filter;
     uint32_t m_nb_hashes;
 };
-
-template<typename ItemHash>
-BloomFilter<ItemHash>::BloomFilter(uint32_t cardinality)
- : m_cardinality{cardinality},
-   m_filter{optimal_filter_size(cardinality), false},
-   m_nb_hashes{optimal_nb_of_hash_functions(cardinality, m_filter.size())}
-{
-}
-
-template<typename ItemHash> template<typename ItemKey> void BloomFilter<ItemHash>::add(const ItemKey& item)
-{
-    HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
-
-    for (size_t i = 0; i < m_nb_hashes; ++i) {
-        const size_t filter_idx = mixer();
-        assert(filter_idx < m_filter.size());
-
-        m_filter.set(filter_idx);
-    }
-}
-
-template<typename ItemHash> void BloomFilter<ItemHash>::clear()
-{
-    m_filter.reset();
-}
-
-template<typename ItemHash> template<typename ItemKey> bool BloomFilter<ItemHash>::maybe_contains(const ItemKey& item) const
-{
-    HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
-
-    for (size_t i = 0; i < m_nb_hashes; ++i) {
-        const size_t filter_idx = mixer();
-        assert(filter_idx < m_filter.size());
-
-        if (!m_filter.test(filter_idx)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-template<typename ItemHash> size_t BloomFilter<ItemHash>::memory_used() const noexcept
-{
-    return m_filter.num_blocks() * sizeof(BitsetBlock) + sizeof(m_nb_hashes);
-}
-
-template<typename ItemHash> double BloomFilter<ItemHash>::saturation() const noexcept
-{
-    assert(m_filter.size() > 0);
-    return static_cast<double>(m_filter.count()) / static_cast<double>(m_filter.size());
-}
 
 }  // namespace cachemere::policy::detail

--- a/include/cachemere/policy/detail/counting_bloom_filter.h
+++ b/include/cachemere/policy/detail/counting_bloom_filter.h
@@ -28,20 +28,52 @@ public:
     ///          while having an estimate that is too low will drastically reduce the accuracy of the filter.
     ///
     /// @param cardinality The expected cardinality of the set to be inserted in the filter.
-    CountingBloomFilter(uint32_t cardinality);
+    CountingBloomFilter(uint32_t cardinality)
+     : m_cardinality{cardinality},
+       m_filter(optimal_filter_size(cardinality), 0),
+       m_nb_hashes{optimal_nb_of_hash_functions(cardinality, m_filter.size())}
+    {
+    }
 
     /// @brief Increment the count for a given item by one.
     /// @param item The item of the counter to increment.
-    template<typename ItemKey> void add(const ItemKey& item);
+    template<typename ItemKey> void add(const ItemKey& item)
+    {
+        const auto [indices, minimum_val] = indices_and_minimum(item);
+
+        // Increment all filter slots corresponding to the minimum value.
+        const uint8_t is_zero_increment = minimum_val == 0 ? 1 : 0;
+        for (const size_t idx : indices) {
+            if (m_filter[idx] == minimum_val) {
+                ++m_filter[idx];
+
+                // We track the number of non-zero values in the filter.
+                // This is used to compute the filter saturation.
+                m_nb_nonzero += is_zero_increment;
+            }
+        }
+    }
 
     /// @brief Clear the filter while keeping the allocated memory.
-    void clear();
+    void clear()
+    {
+        std::ranges::fill(m_filter.begin(), m_filter.end(), 0);
+        m_nb_nonzero = 0;
+    }
 
     /// @brief Divide counter values by two.
     /// @details If the user of this filter doesn't rely on the absolute value of the counters, calling this
     ///          regularly will decrease the saturation of the filter by removing items that are very
     ///          rarely seen.
-    void decay();
+    void decay()
+    {
+        for (auto& counter : m_filter) {
+            if (counter == 1) {
+                --m_nb_nonzero;
+            }
+            counter /= 2;
+        }
+    }
 
     /// @brief Get the counter estimate for a given item.
     /// @param item The item for which to estimate the count.
@@ -50,15 +82,41 @@ public:
     ///          the real counter value - the real count is guaranteed to be less or equal to the estimate
     ///          returned.
     /// @return The counter estimate for the item.
-    template<typename ItemKey> [[nodiscard]] uint32_t estimate(const ItemKey& item) const;
+    template<typename ItemKey> [[nodiscard]] uint32_t estimate(const ItemKey& item) const
+    {
+        assert(m_nb_hashes > 0);
+
+        HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
+
+        uint32_t minimum_val = std::numeric_limits<uint32_t>::max();
+        for (size_t i = 0; i < m_nb_hashes; ++i) {
+            const size_t idx = mixer();
+            assert(idx < m_filter.size());
+
+            minimum_val = std::min(m_filter[idx], minimum_val);
+        }
+
+        return minimum_val;
+    }
 
     /// @brief Get the cardinality of the filter.
     /// @return The cardinality of the filter, as configured.
-    [[nodiscard]] uint32_t cardinality() const noexcept;
+    [[nodiscard]] uint32_t cardinality() const noexcept
+    {
+        return m_cardinality;
+    }
 
     /// @brief Get an estimate of the memory consumption of the filter.
     /// @return The memory used by the filter, in bytes.
-    [[nodiscard]] size_t memory_used() const noexcept;
+    [[nodiscard]] size_t memory_used() const noexcept
+    {
+        // Note:
+        //  The amount of memory could be reduced by using variable-length counters.
+        //  Since we know that reset is triggered once we reach a count of
+        //  m_Cardinality, we could use the smallest numeric type that holds
+        //  m_Cardinality for the internal counters.
+        return m_filter.size() * sizeof(uint32_t) + sizeof(m_cardinality) + sizeof(m_nb_hashes) + sizeof(m_nb_nonzero);
+    }
 
     /// @brief Get the saturation of the filter.
     /// @details As filter saturations increases, so will the probability of false positives.
@@ -66,106 +124,35 @@ public:
     ///          a counter value greater than 1.
     ///          Increasing the filter cardinality will slow down the saturation of the filter, at the cost of using more memory.
     /// @return  The saturation of the filter, as a fraction.
-    [[nodiscard]] double saturation() const noexcept;
+    [[nodiscard]] double saturation() const noexcept
+    {
+        assert(m_filter.size() > 0);
+        return static_cast<double>(m_nb_nonzero) / static_cast<double>(m_filter.size());
+    }
 
 private:
     uint32_t              m_cardinality;
     std::vector<uint32_t> m_filter;
     uint32_t              m_nb_hashes;
     uint32_t              m_nb_nonzero = 0;
+
+    template<typename ItemKey> [[nodiscard]] std::pair<std::vector<size_t>, uint32_t> indices_and_minimum(const ItemKey& item) const
+    {
+        HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
+        std::vector<size_t>          indices;
+        indices.reserve(m_nb_hashes);
+        uint32_t minimum_val = std::numeric_limits<uint32_t>::max();
+
+        for (size_t i = 0; i < m_nb_hashes; ++i) {
+            const size_t idx = mixer();
+            assert(idx < m_filter.size());
+
+            indices.push_back(idx);
+            minimum_val = std::min(m_filter[idx], minimum_val);
+        }
+
+        return {indices, minimum_val};
+    }
 };
-
-template<typename ItemHash>
-CountingBloomFilter<ItemHash>::CountingBloomFilter(uint32_t cardinality)
- : m_cardinality{cardinality},
-   m_filter(optimal_filter_size(cardinality), 0),
-   m_nb_hashes{optimal_nb_of_hash_functions(cardinality, m_filter.size())}
-{
-}
-
-template<typename ItemHash> template<typename ItemKey> void CountingBloomFilter<ItemHash>::add(const ItemKey& item)
-{
-    HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
-
-    std::vector<size_t> indices;
-    indices.reserve(m_nb_hashes);
-
-    uint32_t minimum_val = std::numeric_limits<uint32_t>::max();
-
-    // Generate the indices and find the minimum.
-    for (size_t i = 0; i < m_nb_hashes; ++i) {
-        const size_t idx = mixer();
-        assert(idx < m_filter.size());
-
-        indices.push_back(idx);
-        minimum_val = std::min(m_filter[idx], minimum_val);
-    }
-
-    // Increment all filter slots corresponding to the minimum value.
-    const uint8_t is_zero_increment = minimum_val == 0 ? 1 : 0;
-    for (const size_t idx : indices) {
-        if (m_filter[idx] == minimum_val) {
-            ++m_filter[idx];
-
-            // We track the number of non-zero values in the filter.
-            // This is used to compute the filter saturation.
-            m_nb_nonzero += is_zero_increment;
-        }
-    }
-}
-
-template<typename ItemHash> void CountingBloomFilter<ItemHash>::clear()
-{
-    std::ranges::fill(m_filter.begin(), m_filter.end(), 0);
-    m_nb_nonzero = 0;
-}
-
-template<typename ItemHash> void CountingBloomFilter<ItemHash>::decay()
-{
-    for (auto& counter : m_filter) {
-        if (counter == 1) {
-            --m_nb_nonzero;
-        }
-        counter /= 2;
-    }
-}
-
-template<typename ItemHash> template<typename ItemKey> uint32_t CountingBloomFilter<ItemHash>::estimate(const ItemKey& item) const
-{
-    assert(m_nb_hashes > 0);
-
-    HashMixer<ItemKey, ItemHash> mixer{item, m_filter.size()};
-
-    uint32_t minimum_val = std::numeric_limits<uint32_t>::max();
-    for (size_t i = 0; i < m_nb_hashes; ++i) {
-        const size_t idx = mixer();
-        assert(idx < m_filter.size());
-
-        minimum_val = std::min(m_filter[idx], minimum_val);
-    }
-
-    return minimum_val;
-}
-
-template<typename ItemHash> uint32_t CountingBloomFilter<ItemHash>::cardinality() const noexcept
-{
-    return m_cardinality;
-}
-
-template<typename ItemHash> size_t CountingBloomFilter<ItemHash>::memory_used() const noexcept
-{
-    // Note:
-    //  The amount of memory could be reduced by using variable-length counters.
-    //  Since we know that reset is triggered once we reach a count of
-    //  m_Cardinality, we could use the smallest numeric type that holds
-    //  m_Cardinality for the internal counters.
-    return m_filter.size() * sizeof(uint32_t) + sizeof(m_cardinality) + sizeof(m_nb_hashes) + sizeof(m_nb_nonzero);
-}
-
-template<typename ItemHash> double CountingBloomFilter<ItemHash>::saturation() const noexcept
-{
-    assert(m_filter.size() > 0);
-    return static_cast<double>(m_nb_nonzero) / static_cast<double>(m_filter.size());
-}
 
 }  // namespace cachemere::policy::detail

--- a/include/cachemere/policy/detail/hash_mixer.h
+++ b/include/cachemere/policy/detail/hash_mixer.h
@@ -2,13 +2,15 @@
 
 #include <random>
 
+#include <cachemere/detail/traits.h>
+
 namespace cachemere::policy::detail {
 
 /// @brief Functor used for generating a uniform sequence of numbers in a given value range for a given key.
 /// @tparam Key The type of the key to be used as seed.
 /// @tparam KeyHash The functor to use for turning the provided key into a seed for the internal
 ///                 pseudo-random number generator.
-template<typename Key, typename KeyHash> class HashMixer : private KeyHash
+template<typename Key, cachemere::detail::traits::HasherFor<Key> KeyHash> class HashMixer : private KeyHash
 {
 public:
     /// @brief Constructor.

--- a/include/cachemere/policy/detail/hash_mixer.h
+++ b/include/cachemere/policy/detail/hash_mixer.h
@@ -15,28 +15,23 @@ public:
     /// @param key The key to use to seed this instance.
     /// @param value_range The upper bound of the value range.
     ///                    This mixer will return values in the range `[0, value_range)`.
-    HashMixer(const Key& key, size_t value_range);
+    HashMixer(const Key& key, size_t value_range)
+     : KeyHash{},
+       m_rng{static_cast<std::minstd_rand::result_type>(KeyHash::operator()(key))},
+       m_value_range{value_range}
+    {
+    }
 
     /// @brief Generate the next value in the random sequence.
     /// @return The next value in the sequence.
-    [[nodiscard]] size_t operator()();
+    [[nodiscard]] size_t operator()()
+    {
+        return m_rng() % m_value_range;
+    }
 
 private:
     std::minstd_rand m_rng;
     size_t           m_value_range;
 };
-
-template<typename Key, typename KeyHash>
-HashMixer<Key, KeyHash>::HashMixer(const Key& key, size_t value_range)
- : KeyHash{},
-   m_rng{static_cast<std::minstd_rand::result_type>(KeyHash::operator()(key))},
-   m_value_range{value_range}
-{
-}
-
-template<typename Key, typename KeyHash> size_t HashMixer<Key, KeyHash>::operator()()
-{
-    return m_rng() % m_value_range;
-}
 
 }  // namespace cachemere::policy::detail

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -8,10 +8,16 @@
 #include <absl/container/btree_map.h>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/traits.h>
 
 #include "detail/counting_bloom_filter.h"
 
 namespace cachemere::policy {
+
+template<typename T, typename Key, typename Value>
+concept CostFn = requires(T t, Key key, Item<Value> item) {
+    { t(key, item) } -> std::convertible_to<uint64_t>;
+};
 
 /// @brief Greedy-Dual-Size-Frequency (GDSF) eviction policy.
 /// @details Generally, GDSF tries to first evict the items that will be the least costly
@@ -24,7 +30,7 @@ namespace cachemere::policy {
 /// @tparam Cost A functor taking a a `Key&` and a `const Item<Value>&` returning the cost to load this item in cache.
 //          The cost must not exceed 2^64 and should ideally be quite a bit below this limit since the cost of the item is added to the
 //          policy's internal 64-bit clock on every insertion.
-template<typename Key, typename KeyHash, typename Value, typename Cost> class EvictionGDSF
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value, CostFn<Key, Value> Cost> class EvictionGDSF
 {
 private:
     using KeyRef = std::reference_wrapper<const Key>;

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -30,9 +30,14 @@ private:
     using KeyRef = std::reference_wrapper<const Key>;
 
     struct PriorityEntry {
-        PriorityEntry(KeyRef key, double coefficient);
+        PriorityEntry(KeyRef key, double coefficient) : m_key{key}, m_h_coefficient{coefficient}
+        {
+        }
 
-        bool operator<(const PriorityEntry& other) const;
+        bool operator<(const PriorityEntry& other) const
+        {
+            return m_h_coefficient < other.m_h_coefficient;
+        }
 
         KeyRef m_key;
         double m_h_coefficient;
@@ -61,7 +66,12 @@ public:
     using CacheItem = Item<Value>;
 
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_priority_set.clear();
+        m_iterator_map.clear();
+        m_frequency_sketch.clear();
+    }
 
     /// @brief Set the cardinality of the policy.
     /// @details The set cardinality should be a decent approximation of the cardinality
@@ -69,32 +79,64 @@ public:
     ///          accurate estimate is very important, because an underestimation will severely
     ///          decrease the accuracy of the policy, while an overestimation will use too much memory.
     /// @param cardinality The expected cardinality of the set of items.
-    void set_cardinality(uint32_t cardinality);
+    void set_cardinality(uint32_t cardinality)
+    {
+        m_frequency_sketch = detail::CountingBloomFilter<Key>{cardinality};
+    }
 
     /// @brief Insertion event handler.
     /// @details Computes a coefficient for the item and inserts it in the priority queue.
     /// @param key The key of the inserted item.
     /// @param item The item that has been inserted in cache.
-    void on_insert(const Key& key, const CacheItem& item);
+    void on_insert(const Key& key, const CacheItem& item)
+    {
+        m_frequency_sketch.add(key);
+
+        assert(m_iterator_map.find(std::ref(key)) == m_iterator_map.end());
+
+        const auto it = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
+        m_iterator_map.emplace(std::ref(key), it);
+    }
 
     /// @brief Update event handler.
     /// @details Updates the coefficient for this item and changes its position in the priority queue.
     /// @param key The key that has been updated in the cache.
     /// @param old_item The old value for this key.
     /// @param new_item The new value for this key.
-    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    void on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
+    {
+        on_cache_hit(key, new_item);
+    }
 
     /// @brief Cache hit event handler.
     /// @details Updates the coefficient for this item and changes its position in the priority queue.
     /// @param key The key that has been hit.
     /// @param item The item that has been hit.
-    void on_cache_hit(const Key& key, const CacheItem& item);
+    void on_cache_hit(const Key& key, const CacheItem& item)
+    {
+        auto keyref_and_it = m_iterator_map.find(std::ref(key));
+        assert(keyref_and_it != m_iterator_map.end());
+
+        m_frequency_sketch.add(key);
+        m_priority_set.erase(keyref_and_it->second);
+        keyref_and_it->second = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
+    }
 
     /// @brief Eviction event handler.
     /// @details Removes the item from the priority queue.
     /// @param key The key that was evicted.
     /// @param item The item that was evicted.
-    void on_evict(const Key& key, const CacheItem& item);
+    void on_evict(const Key& key, const CacheItem& /* item */)
+    {
+        auto keyref_and_it = m_iterator_map.find(std::ref(key));
+        assert(keyref_and_it != m_iterator_map.end());
+
+        const auto priority_it = keyref_and_it->second;
+        update_clock(static_cast<uint64_t>(priority_it->m_h_coefficient));
+
+        m_priority_set.erase(priority_it);
+        m_iterator_map.erase(keyref_and_it);
+    }
 
     Ticket pop_victim()
     {
@@ -135,80 +177,16 @@ private:
 
     uint64_t m_clock{0};
 
-    [[nodiscard]] double get_h_coefficient(const Key& key, const CacheItem& item) const noexcept;
-    void                 update_clock(uint64_t new_clock)
+    [[nodiscard]] double get_h_coefficient(const Key& key, const CacheItem& item) const noexcept
+    {
+        return static_cast<double>(m_clock) + static_cast<double>(m_frequency_sketch.estimate(key)) *
+                                                  (static_cast<double>(m_measure_cost(key, item)) / static_cast<double>(item.m_total_size));
+    }
+
+    void update_clock(uint64_t new_clock)
     {
         m_clock = std::max(m_clock, new_clock);
     }
 };
-
-template<class Key, class KeyHash, class Value, class Cost>
-EvictionGDSF<Key, KeyHash, Value, Cost>::PriorityEntry::PriorityEntry(KeyRef key, double coefficient) : m_key(key),
-                                                                                                        m_h_coefficient(coefficient)
-{
-}
-
-template<class Key, class KeyHash, class Value, class Cost>
-bool EvictionGDSF<Key, KeyHash, Value, Cost>::PriorityEntry::operator<(const PriorityEntry& other) const
-{
-    return m_h_coefficient < other.m_h_coefficient;
-}
-
-template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::clear()
-{
-    m_priority_set.clear();
-    m_iterator_map.clear();
-    m_frequency_sketch.clear();
-}
-
-template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::set_cardinality(uint32_t cardinality)
-{
-    m_frequency_sketch = detail::CountingBloomFilter<Key>{cardinality};
-}
-
-template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_insert(const Key& key, const CacheItem& item)
-{
-    m_frequency_sketch.add(key);
-
-    assert(m_iterator_map.find(std::ref(key)) == m_iterator_map.end());
-
-    const auto it = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
-    m_iterator_map.emplace(std::ref(key), it);
-}
-
-template<class Key, class KeyHash, class Value, class Cost>
-void EvictionGDSF<Key, KeyHash, Value, Cost>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
-{
-    on_cache_hit(key, new_item);
-}
-
-template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_cache_hit(const Key& key, const CacheItem& item)
-{
-    auto keyref_and_it = m_iterator_map.find(std::ref(key));
-    assert(keyref_and_it != m_iterator_map.end());
-
-    m_frequency_sketch.add(key);
-    m_priority_set.erase(keyref_and_it->second);
-    keyref_and_it->second = m_priority_set.emplace(std::ref(key), get_h_coefficient(key, item));
-}
-
-template<class Key, class KeyHash, class Value, class Cost> void EvictionGDSF<Key, KeyHash, Value, Cost>::on_evict(const Key& key, const CacheItem& /* item */)
-{
-    auto keyref_and_it = m_iterator_map.find(std::ref(key));
-    assert(keyref_and_it != m_iterator_map.end());
-
-    const auto priority_it = keyref_and_it->second;
-    update_clock(static_cast<uint64_t>(priority_it->m_h_coefficient));
-
-    m_priority_set.erase(priority_it);
-    m_iterator_map.erase(keyref_and_it);
-}
-
-template<class Key, class KeyHash, class Value, class Cost>
-double EvictionGDSF<Key, KeyHash, Value, Cost>::get_h_coefficient(const Key& key, const CacheItem& item) const noexcept
-{
-    return static_cast<double>(m_clock) +
-           static_cast<double>(m_frequency_sketch.estimate(key)) * (static_cast<double>(m_measure_cost(key, item)) / static_cast<double>(item.m_total_size));
-}
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/eviction_gdsf.h
+++ b/include/cachemere/policy/eviction_gdsf.h
@@ -87,7 +87,7 @@ public:
     /// @param cardinality The expected cardinality of the set of items.
     void set_cardinality(uint32_t cardinality)
     {
-        m_frequency_sketch = detail::CountingBloomFilter<Key>{cardinality};
+        m_frequency_sketch = detail::CountingBloomFilter<KeyHash>{cardinality};
     }
 
     /// @brief Insertion event handler.

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/traits.h>
 
 namespace cachemere::policy {
 
@@ -17,7 +18,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class EvictionLRU
+template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class EvictionLRU
 {
 private:
     using KeyRef    = std::reference_wrapper<const Key>;

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -41,107 +41,92 @@ public:
     };
 
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_keys.clear();
+        m_nodes.clear();
+    }
 
     /// @brief Insertion event handler.
     /// @details Inserts the provided item at the front of the list.
     /// @param key The key of the inserted item.
     /// @param item The item that has been inserted in cache.
-    void on_insert(const Key& key, const CacheItem& item);
+    void on_insert(const Key& key, const CacheItem& /* item */)
+    {
+        assert(m_nodes.find(std::ref(key)) == m_nodes.end());  // Validate the item is not already in policy.
+        m_keys.emplace_front(std::ref(key));
+        m_nodes.emplace(std::ref(key), m_keys.begin());
+    }
 
     /// @brief Update event handler.
     /// @details Moves the provided item to the front of the list.
     /// @param key The key that has been updated in the cache.
     /// @param old_item The old value for this key.
     /// @param new_item The new value for this key
-    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    void on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
+    {
+        on_cache_hit(key, new_item);
+    }
 
     /// @brief Cache hit event handler.
     /// @details Moves the provided item at the front of the list.
     /// @param key The key that has been hit.
     /// @param item The item that has been hit.
-    void on_cache_hit(const Key& key, const CacheItem& item);
+    void on_cache_hit(const Key& key, const CacheItem& /* item */)
+    {
+        auto node_it = m_nodes.find(key);
+        if (node_it != m_nodes.end()) {
+            // No need to shuffle stuff around if item is already the hottest item in cache.
+            if (node_it->second != m_keys.begin()) {
+                m_keys.splice(m_keys.begin(), m_keys, node_it->second);
+            }
+        } else {
+            // If this is tripped, there is a disconnect between the contents of the policy and the contents of the cache.
+            assert(false);
+        }
+    }
 
     /// @brief Eviction event handler.
     /// @details Removes the item at the back of the list - ensuring it has the provided key.
     /// @param key The key that was evicted.
     /// @param item The item that was evicted.
-    void on_evict(const Key& key, const CacheItem& item);
+    void on_evict(const Key& key, const CacheItem& /* item */)
+    {
+        assert(!m_nodes.empty());
+        assert(!m_keys.empty());
 
-    [[nodiscard]] Ticket pop_victim();
-    void                 rollback(Ticket ticket);
+        if (m_keys.back().get() == key) {
+            m_nodes.erase(key);
+            m_keys.pop_back();
+        } else {
+            auto it = m_nodes.find(key);
+            assert(it != m_nodes.end());
+            m_keys.erase(it->second);
+            m_nodes.erase(it);
+        }
+    }
+
+    [[nodiscard]] Ticket pop_victim()
+    {
+        assert(!m_keys.empty());
+
+        const KeyRef victim_key = m_keys.back();
+        m_nodes.erase(victim_key);
+        m_keys.pop_back();
+        return Ticket{victim_key};
+    }
+
+    void rollback(Ticket ticket)
+    {
+        assert(m_nodes.find(ticket.m_key) == m_nodes.end());
+
+        m_keys.emplace_back(ticket.m_key);
+        m_nodes.emplace(ticket.m_key, std::prev(m_keys.end()));
+    }
 
 private:
     std::list<KeyRef> m_keys;
     KeyRefMap         m_nodes;
 };
-
-template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::clear()
-{
-    m_keys.clear();
-    m_nodes.clear();
-}
-
-template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_insert(const Key& key, const CacheItem& /* item */)
-{
-    assert(m_nodes.find(std::ref(key)) == m_nodes.end());  // Validate the item is not already in policy.
-
-    m_keys.emplace_front(std::ref(key));
-    m_nodes.emplace(std::ref(key), m_keys.begin());
-}
-
-template<class Key, class KeyHash, class Value>
-void EvictionLRU<Key, KeyHash, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
-{
-    on_cache_hit(key, new_item);
-}
-
-template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
-{
-    auto node_it = m_nodes.find(key);
-    if (node_it != m_nodes.end()) {
-        // No need to shuffle stuff around if item is already the hottest item in cache.
-        if (node_it->second != m_keys.begin()) {
-            m_keys.splice(m_keys.begin(), m_keys, node_it->second);
-        }
-    } else {
-        // If this is tripped, there is a disconnect between the contents of the policy and the contents of the cache.
-        assert(false);
-    }
-}
-
-template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::on_evict(const Key& key, const CacheItem& /* item */)
-{
-    assert(!m_nodes.empty());
-    assert(!m_keys.empty());
-
-    if (m_keys.back().get() == key) {
-        m_nodes.erase(key);
-        m_keys.pop_back();
-    } else {
-        auto it = m_nodes.find(key);
-        assert(it != m_nodes.end());
-        m_keys.erase(it->second);
-        m_nodes.erase(it);
-    }
-}
-
-template<class Key, class KeyHash, class Value> auto EvictionLRU<Key, KeyHash, Value>::pop_victim() -> Ticket
-{
-    assert(!m_keys.empty());
-
-    const KeyRef victim_key = m_keys.back();
-    m_nodes.erase(victim_key);
-    m_keys.pop_back();
-    return Ticket{victim_key};
-}
-
-template<class Key, class KeyHash, class Value> void EvictionLRU<Key, KeyHash, Value>::rollback(Ticket ticket)
-{
-    assert(m_nodes.find(ticket.m_key) == m_nodes.end());
-
-    m_keys.emplace_back(ticket.m_key);
-    m_nodes.emplace(ticket.m_key, std::prev(m_keys.end()));
-}
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/eviction_lru.h
+++ b/include/cachemere/policy/eviction_lru.h
@@ -18,7 +18,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<detail::traits::Key Key, detail::traits::HasherFor<Key> KeyHash, typename Value> class EvictionLRU
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class EvictionLRU
 {
 private:
     using KeyRef    = std::reference_wrapper<const Key>;

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/traits.h>
 
 namespace cachemere::policy {
 
@@ -21,7 +22,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class EvictionSegmentedLRU
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class EvictionSegmentedLRU
 {
 private:
     using KeyRef    = std::reference_wrapper<const Key>;

--- a/include/cachemere/policy/eviction_segmented_lru.h
+++ b/include/cachemere/policy/eviction_segmented_lru.h
@@ -31,9 +31,8 @@ private:
 public:
     using CacheItem = cachemere::Item<Value>;
 
-    struct EvictionTicket
-    {
-        EvictionTicket(KeyRef key, bool from_probation) : m_key{key}, m_from_probation{from_probation}
+    struct Ticket {
+        Ticket(KeyRef key, bool from_probation) : m_key{key}, m_from_probation{from_probation}
         {
         }
 
@@ -46,20 +45,34 @@ public:
         bool   m_from_probation;
     };
 
-    using Ticket = EvictionTicket;
-
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_probation_list.clear();
+        m_probation_nodes.clear();
+
+        m_protected_list.clear();
+        m_protected_nodes.clear();
+    }
 
     /// @brief Set the maximum number of items in the protected LRU segment.
     /// @param size The maximum number of items in the protected segment.
-    void set_protected_segment_size(size_t size);
+    void set_protected_segment_size(const size_t size)
+    {
+        m_protected_segment_size = size;
+    }
 
     /// @brief Insertion event handler.
     /// @details Inserts the provided item at the front of the probation segment.
     /// @param key The key of the inserted item.
     /// @param item The item that has been inserted in the cache.
-    void on_insert(const Key& key, const CacheItem& item);
+    void on_insert(const Key& key, const CacheItem& /* item */)
+    {
+        assert(m_probation_nodes.find(key) == m_probation_nodes.end());
+
+        m_probation_list.emplace_front(std::ref(key));
+        m_probation_nodes.emplace(std::ref(key), m_probation_list.begin());
+    }
 
     /// @brief Update event handler.
     /// @details If the item is in the probation segment, it is moved to the protected
@@ -68,7 +81,10 @@ public:
     /// @param key The key that has been updated in the cache.
     /// @param old_item The old value for this key.
     /// @param new_item The new value for this key
-    void on_update(const Key& key, const CacheItem& old_item, const CacheItem& new_item);
+    void on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
+    {
+        on_cache_hit(key, new_item);
+    }
 
     /// @brief Cache hit event handler.
     /// @details If the item is in the probation segment, it is moved to the protected
@@ -76,16 +92,69 @@ public:
     ///          the protected segment.
     /// @param key The key that has been hit.
     /// @param item The item that has been hit.
-    void on_cache_hit(const Key& key, const CacheItem& item);
+    void on_cache_hit(const Key& key, const CacheItem& /* item */)
+    {
+        assert(m_probation_nodes.size() == m_probation_list.size());
+        assert(m_protected_nodes.size() == m_protected_list.size());
+
+        auto protected_node_it = m_protected_nodes.find(key);
+        if (protected_node_it != m_protected_nodes.end()) {
+            if (protected_node_it->second != m_protected_list.begin()) {
+                // If the node is in the protected segment, move it to the front of the protected segment.
+                m_protected_list.splice(m_protected_list.begin(), m_protected_list, protected_node_it->second);
+            }
+        } else {
+            // If the node is in probation, move it to the protected segment.
+            [[maybe_unused]] const bool promotion_ok = move_to_protected(key);
+            assert(promotion_ok);
+        }
+
+        trim_protected_segment();
+
+        assert(m_probation_nodes.size() == m_probation_list.size());
+        assert(m_protected_nodes.size() == m_protected_list.size());
+    }
 
     /// @brief Eviction event handler.
     /// @details Removes the item from the segment it belongs to.
     /// @param key The key that was evicted.
     /// @param item The item that was evicted.
-    void on_evict(const Key& key, const CacheItem& item);
+    void on_evict(const Key& key, const CacheItem& /* item */)
+    {
+        assert((!m_protected_list.empty()) || !m_probation_list.empty());
 
-    [[nodiscard]] Ticket pop_victim();
-    void rollback(Ticket ticket);
+        auto key_and_it = m_probation_nodes.find(key);
+        if (key_and_it != m_probation_nodes.end()) {
+            m_probation_list.erase(key_and_it->second);
+            m_probation_nodes.erase(key_and_it);
+        } else {
+            key_and_it = m_protected_nodes.find(key);
+            assert(key_and_it != m_protected_nodes.end());
+            m_protected_list.erase(key_and_it->second);
+            m_protected_nodes.erase(key_and_it);
+        }
+    }
+
+    [[nodiscard]] Ticket pop_victim()
+    {
+        if (!m_probation_list.empty()) {
+            return pop_victim_from_probation();
+        }
+        return pop_victim_from_protected();
+    }
+
+    void rollback(Ticket ticket)
+    {
+        if (ticket.m_from_probation) {
+            assert(m_probation_nodes.find(ticket.m_key) == m_probation_nodes.end());
+            m_probation_list.emplace_back(ticket.m_key);
+            m_probation_nodes.emplace(ticket.m_key, std::prev(m_probation_list.end()));
+        } else {
+            assert(m_protected_nodes.find(ticket.m_key) == m_protected_nodes.end());
+            m_protected_list.emplace_back(ticket.m_key);
+            m_protected_nodes.emplace(ticket.m_key, std::prev(m_protected_list.end()));
+        }
+    }
 
 private:
     size_t m_protected_segment_size;
@@ -96,133 +165,57 @@ private:
     std::list<KeyRef> m_protected_list;
     KeyRefMap         m_protected_nodes;
 
-    bool move_to_protected(const Key& key);
-    bool pop_to_probation();
-};
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::clear()
-{
-    m_probation_list.clear();
-    m_probation_nodes.clear();
-
-    m_protected_list.clear();
-    m_protected_nodes.clear();
-}
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::set_protected_segment_size(size_t size)
-{
-    m_protected_segment_size = size;
-}
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::on_insert(const Key& key, const CacheItem& /* item */)
-{
-    assert(m_probation_nodes.find(key) == m_probation_nodes.end());
-
-    m_probation_list.emplace_front(std::ref(key));
-    m_probation_nodes.emplace(std::ref(key), m_probation_list.begin());
-}
-
-template<class Key, class KeyHash, class Value>
-void EvictionSegmentedLRU<Key, KeyHash, Value>::on_update(const Key& key, const CacheItem& /* old_item */, const CacheItem& new_item)
-{
-    on_cache_hit(key, new_item);
-}
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
-{
-    assert(m_probation_nodes.size() == m_probation_list.size());
-    assert(m_protected_nodes.size() == m_protected_list.size());
-
-    auto protected_node_it = m_protected_nodes.find(key);
-    if (protected_node_it != m_protected_nodes.end()) {
-        if (protected_node_it->second != m_protected_list.begin()) {
-            // If the node is in the protected segment, move it to the front of the protected segment.
-            m_protected_list.splice(m_protected_list.begin(), m_protected_list, protected_node_it->second);
+    bool move_to_protected(const Key& key)
+    {
+        auto probation_node_it = m_probation_nodes.find(key);
+        if (probation_node_it == m_probation_nodes.end()) {
+            return false;
         }
-    } else {
-        // If the node is in probation, move it to the protected segment.
-        [[maybe_unused]] const bool promotion_ok = move_to_protected(key);
-        assert(promotion_ok);
+
+        m_protected_list.splice(m_protected_list.begin(), m_probation_list, probation_node_it->second);
+        m_probation_nodes.erase(key);
+        m_protected_nodes.emplace(key, m_protected_list.begin());
+        return true;
     }
 
-    while (m_protected_list.size() > m_protected_segment_size) {
-        [[maybe_unused]] const bool demotion_ok = pop_to_probation();
-        assert(demotion_ok);
-        assert(m_protected_list.size() == m_protected_segment_size);
+    bool pop_to_probation()
+    {
+        if (m_protected_list.empty()) {
+            return false;
+        }
+
+        m_probation_list.splice(m_probation_list.begin(), m_protected_list, --m_protected_list.end());
+        m_protected_nodes.erase(*m_probation_list.begin());
+        m_probation_nodes.emplace(*m_probation_list.begin(), m_probation_list.begin());
+        return true;
     }
 
-    assert(m_probation_nodes.size() == m_probation_list.size());
-    assert(m_protected_nodes.size() == m_protected_list.size());
-}
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::on_evict(const Key& key, const CacheItem& /* item */)
-{
-    assert((!m_protected_list.empty()) || !m_probation_list.empty());
-
-    auto key_and_it = m_probation_nodes.find(key);
-    if (key_and_it != m_probation_nodes.end()) {
-        m_probation_list.erase(key_and_it->second);
-        m_probation_nodes.erase(key_and_it);
-    } else {
-        key_and_it = m_protected_nodes.find(key);
-        assert(key_and_it != m_protected_nodes.end());
-        m_protected_list.erase(key_and_it->second);
-        m_protected_nodes.erase(key_and_it);
+    void trim_protected_segment()
+    {
+        while (m_protected_list.size() > m_protected_segment_size) {
+            [[maybe_unused]] const bool demotion_ok = pop_to_probation();
+            assert(demotion_ok);
+            assert(m_protected_list.size() == m_protected_segment_size);
+        }
     }
-}
 
-template<class Key, class KeyHash, class Value> auto EvictionSegmentedLRU<Key, KeyHash, Value>::pop_victim() -> Ticket
-{
-    if (!m_probation_list.empty()) {
+    Ticket pop_victim_from_probation()
+    {
+        assert(!m_probation_list.empty());
         const KeyRef victim_key = m_probation_list.back();
         m_probation_nodes.erase(victim_key);
         m_probation_list.pop_back();
         return Ticket{victim_key, true};
     }
 
-    assert(!m_protected_list.empty());
-    const KeyRef victim_key = m_protected_list.back();
-    m_protected_nodes.erase(victim_key);
-    m_protected_list.pop_back();
-    return Ticket{victim_key, false};
-}
-
-template<class Key, class KeyHash, class Value> void EvictionSegmentedLRU<Key, KeyHash, Value>::rollback(Ticket ticket)
-{
-    if (ticket.m_from_probation) {
-        assert(m_probation_nodes.find(ticket.m_key) == m_probation_nodes.end());
-        m_probation_list.emplace_back(ticket.m_key);
-        m_probation_nodes.emplace(ticket.m_key, std::prev(m_probation_list.end()));
-    } else {
-        assert(m_protected_nodes.find(ticket.m_key) == m_protected_nodes.end());
-        m_protected_list.emplace_back(ticket.m_key);
-        m_protected_nodes.emplace(ticket.m_key, std::prev(m_protected_list.end()));
+    Ticket pop_victim_from_protected()
+    {
+        assert(!m_protected_list.empty());
+        const KeyRef victim_key = m_protected_list.back();
+        m_protected_nodes.erase(victim_key);
+        m_protected_list.pop_back();
+        return Ticket{victim_key, false};
     }
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionSegmentedLRU<Key, KeyHash, Value>::move_to_protected(const Key& key)
-{
-    auto probation_node_it = m_probation_nodes.find(key);
-    if (probation_node_it == m_probation_nodes.end()) {
-        return false;
-    }
-
-    m_protected_list.splice(m_protected_list.begin(), m_probation_list, probation_node_it->second);
-    m_probation_nodes.erase(key);
-    m_protected_nodes.emplace(key, m_protected_list.begin());
-    return true;
-}
-
-template<class Key, class KeyHash, class Value> bool EvictionSegmentedLRU<Key, KeyHash, Value>::pop_to_probation()
-{
-    if (m_protected_list.empty()) {
-        return false;
-    }
-
-    m_probation_list.splice(m_probation_list.begin(), m_protected_list, --m_protected_list.end());
-    m_protected_nodes.erase(*m_probation_list.begin());
-    m_probation_nodes.emplace(*m_probation_list.begin(), m_probation_list.begin());
-    return true;
-}
+};
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/insertion_always.h
+++ b/include/cachemere/policy/insertion_always.h
@@ -10,35 +10,28 @@ template<typename Key, typename KeyHash, typename Value> class InsertionAlways
 {
 public:
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+    }
 
     /// @brief Determines whether a given key should be inserted into the cache.
     /// @details For this policy, `should_add` always returns true.
     /// @param key The key of the insertion candidate.
     /// @return Whether the candidate should be inserted into the cache.
-    bool should_add(const Key& key);
+    bool should_add(const Key& /* key */)
+    {
+        return true;
+    }
 
     /// @brief Determines whether a given victim should be replaced by a given candidate.
     /// @details For this policy, `should_replace` always returns true.
     /// @param victim The key of the victim the candidate will be compared to.
     /// @param candidate The key of the insertion candidate.
     /// @return Whether the victim should be replaced by the candidate.
-    bool should_replace(const Key& victim, const Key& candidate);
+    bool should_replace(const Key& /* victim */, const Key& /* candidate */)
+    {
+        return true;
+    }
 };
-
-template<typename Key, typename KeyHash, typename Value> void InsertionAlways<Key, KeyHash, Value>::clear()
-{
-}
-
-template<typename Key, typename KeyHash, typename Value> bool InsertionAlways<Key, KeyHash, Value>::should_add(const Key& /* key */)
-{
-    return true;
-}
-
-template<typename Key, typename KeyHash, typename Value>
-bool InsertionAlways<Key, KeyHash, Value>::should_replace(const Key& /* key */, const Key& /* candidate */)
-{
-    return true;
-}
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/insertion_always.h
+++ b/include/cachemere/policy/insertion_always.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <cachemere/detail/traits.h>
+
 namespace cachemere::policy {
 
 /// @brief Simplest insertion policy. Always accepts insertions.
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class InsertionAlways
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class InsertionAlways
 {
 public:
     /// @brief Clears the policy.

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -23,18 +23,28 @@ public:
     using CacheItem = cachemere::Item<Value>;
 
     /// @brief Clears the policy.
-    void clear();
+    void clear()
+    {
+        m_gatekeeper.clear();
+        m_frequency_sketch.clear();
+    }
 
     /// @brief Cache hit event handler.
     /// @details Updates the internal frequency sketches for the given item.
     /// @param key The key that has been hit.
     /// @param item The item that has been hit.
-    void on_cache_hit(const Key& key, const CacheItem& item);
+    void on_cache_hit(const Key& key, const CacheItem& /* item */)
+    {
+        touch_item(key);
+    }
 
     /// @brief Cache miss event handler.
     /// @details Updates the internal frequency sketches for the given key.
     /// @param key The key that was missed.
-    template<typename KeyType> void on_cache_miss(const KeyType& key);
+    template<typename KeyType> void on_cache_miss(const KeyType& key)
+    {
+        touch_item(key);
+    }
 
     /// @brief Set the cardinality of the policy.
     /// @details The set cardinality should be a decent approximation of the cardinality
@@ -42,12 +52,19 @@ public:
     ///          accurate estimate is very important, because an underestimation will severely
     ///          decrease the accuracy of the policy, while an overestimation will use too much memory.
     /// @param cardinality The expected cardinality of the set of items.
-    void set_cardinality(uint32_t cardinality);
+    void set_cardinality(uint32_t cardinality)
+    {
+        m_gatekeeper       = detail::BloomFilter<KeyHash>(cardinality);
+        m_frequency_sketch = detail::CountingBloomFilter<KeyHash>(cardinality);
+    }
 
     /// @brief Determines whether a given key should be inserted into the cache.
     /// @details TinyLFU always accepts insertions of items if there is room for them in the cache.
     /// @param key The key of the insertion candidate.
-    bool should_add(const Key& key);
+    bool should_add(const Key& key)
+    {
+        return m_gatekeeper.maybe_contains(key);
+    }
 
     /// @brief Determines whether a given victim should be replaced by a given candidate.
     /// @details TinyLFU will use its internal sketches to build a frequency
@@ -55,77 +72,43 @@ public:
     ///          that the candidate key is accessed more frequently than the victim key.
     /// @param victim The key of the victim the candidate will be compared to.
     /// @param candidate The replacement candidate.
-    bool should_replace(const Key& victim, const Key& candidate);
+    bool should_replace(const Key& victim, const Key& candidate)
+    {
+        return estimate_count_for_key(candidate) > estimate_count_for_key(victim);
+    }
 
 private:
     const static uint32_t                DEFAULT_CACHE_CARDINALITY = 2000;
     detail::BloomFilter<KeyHash>         m_gatekeeper{DEFAULT_CACHE_CARDINALITY};        // TODO: Investigate using cuckoo filter here instead.
     detail::CountingBloomFilter<KeyHash> m_frequency_sketch{DEFAULT_CACHE_CARDINALITY};  // TODO: Replace with count-min sketch to get rid of cardinality param.
 
-    uint32_t estimate_count_for_key(const Key& key) const;
-    void     reset();
-
-    template<typename KeyType> void touch_item(const KeyType& key);
-};
-
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::clear()
-{
-    m_gatekeeper.clear();
-    m_frequency_sketch.clear();
-}
-
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_hit(const Key& key, const CacheItem& /* item */)
-{
-    touch_item(key);
-}
-
-template<class Key, class KeyHash, class Value> template<class KeyType> void InsertionTinyLFU<Key, KeyHash, Value>::on_cache_miss(const KeyType& key)
-{
-    touch_item(key);
-}
-
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::set_cardinality(uint32_t cardinality)
-{
-    m_gatekeeper       = detail::BloomFilter<KeyHash>(cardinality);
-    m_frequency_sketch = detail::CountingBloomFilter<KeyHash>(cardinality);
-}
-
-template<class Key, class KeyHash, class Value> bool InsertionTinyLFU<Key, KeyHash, Value>::should_add(const Key& key)
-{
-    return m_gatekeeper.maybe_contains(key);
-}
-
-template<class Key, class KeyHash, class Value> bool InsertionTinyLFU<Key, KeyHash, Value>::should_replace(const Key& victim, const Key& candidate)
-{
-    return estimate_count_for_key(candidate) > estimate_count_for_key(victim);
-}
-
-template<class Key, class KeyHash, class Value> uint32_t InsertionTinyLFU<Key, KeyHash, Value>::estimate_count_for_key(const Key& key) const
-{
-    uint32_t sketch_estimation = m_frequency_sketch.estimate(key);
-    if (m_gatekeeper.maybe_contains(key)) {
-        ++sketch_estimation;
-    }
-
-    return sketch_estimation;
-}
-
-template<class Key, class KeyHash, class Value> void InsertionTinyLFU<Key, KeyHash, Value>::reset()
-{
-    m_gatekeeper.clear();
-    m_frequency_sketch.decay();
-}
-
-template<class Key, class KeyHash, class Value> template<class KeyType> void InsertionTinyLFU<Key, KeyHash, Value>::touch_item(const KeyType& key)
-{
-    if (m_gatekeeper.maybe_contains(key)) {
-        m_frequency_sketch.add(key);
-        if (m_frequency_sketch.estimate(key) > m_frequency_sketch.cardinality()) {
-            reset();
+    uint32_t estimate_count_for_key(const Key& key) const
+    {
+        uint32_t sketch_estimation = m_frequency_sketch.estimate(key);
+        if (m_gatekeeper.maybe_contains(key)) {
+            ++sketch_estimation;
         }
-    } else {
-        m_gatekeeper.add(key);
+
+        return sketch_estimation;
     }
-}
+
+    void reset()
+    {
+        m_gatekeeper.clear();
+        m_frequency_sketch.decay();
+    }
+
+    template<typename KeyType> void touch_item(const KeyType& key)
+    {
+        if (m_gatekeeper.maybe_contains(key)) {
+            m_frequency_sketch.add(key);
+            if (m_frequency_sketch.estimate(key) > m_frequency_sketch.cardinality()) {
+                reset();
+            }
+        } else {
+            m_gatekeeper.add(key);
+        }
+    }
+};
 
 }  // namespace cachemere::policy

--- a/include/cachemere/policy/insertion_tinylfu.h
+++ b/include/cachemere/policy/insertion_tinylfu.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <cachemere/item.h>
+#include <cachemere/detail/traits.h>
 
 #include "detail/bloom_filter.h"
 #include "detail/counting_bloom_filter.h"
@@ -17,7 +18,7 @@ namespace cachemere::policy {
 /// @tparam Key The type of the keys used to identify items in the cache.
 /// @tparam KeyHash The type of the hasher used to hash item keys.
 /// @tparam Value The type of the values stored in the cache.
-template<typename Key, typename KeyHash, typename Value> class InsertionTinyLFU
+template<cachemere::detail::traits::Key Key, cachemere::detail::traits::HasherFor<Key> KeyHash, typename Value> class InsertionTinyLFU
 {
 public:
     using CacheItem = cachemere::Item<Value>;


### PR DESCRIPTION
## Changes
- Move implementation of template methods inline with their declaration
  - I know this is contrary to how we usually do things, but I feel that in this case it was doing more harm than good to repeat
```cpp
template<class K,
         class V,
         template<class, class, class> class I,
         template<class, class, class> class E,
         template<class, class, class> class C,
         class SV,
         class SK,
         class KH,
         LockingStrategy L>
bool Cache<K, V, I, E, C, SV, SK, KH, L>::insert_locked(K key, V value)
```

for every method.

- Add new concepts to constrain cache generics